### PR TITLE
Fix Vercel import crash + OOM hardening for upload pipeline (#88)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ uploads/
 examples/*/
 .venv-dev/
 tmp/
+.vercel
+.env*

--- a/api/upload.py
+++ b/api/upload.py
@@ -607,15 +607,42 @@ class ProgressReporter:
 
 # ── Lazy report registry ──────────────────────────────────────────────────────
 #
-# Extracted archives are kept on disk (instead of being deleted right after
-# the initial response) so that Process Details timestamps can be fetched
-# on demand via GET /api/chunk. A background sweep removes anything older
-# than REPORT_TTL_SECONDS, mirroring the legacy Flask app's cleanup thread.
+# Only the handful of files actually needed to serve on-demand /api/chunk
+# requests are kept on disk (instead of the whole extracted archive) so that
+# Process Details timestamps can be fetched later. A background sweep removes
+# anything older than REPORT_TTL_SECONDS as a backstop, but most of the memory
+# footprint is released immediately: unused extracted files are deleted right
+# after the pipeline finishes, and the (potentially huge) in-memory `result`
+# JSON is dropped as soon as it has been delivered once via GET /api/progress.
+# This matters on memory-constrained hosts (small containers, Vercel
+# functions) where /tmp is often RAM-backed (tmpfs) — see issue #88.
 
-REPORT_TTL_SECONDS = 15 * 60
+REPORT_TTL_SECONDS = int(os.environ.get('REPORT_TTL_SECONDS', 15 * 60))
 REPORTS: dict = {}
 _REPORTS_LOCK = threading.Lock()
 _cleanup_started = False
+
+
+def _prune_work_dir(work_dir: str, sections: dict):
+    """Delete every extracted file that isn't referenced by `sections` (i.e.
+    not needed later for on-demand /api/chunk reads). Frees the bulk of a
+    report's disk/RAM footprint (mpstat.txt, ps.txt, iostat, etc. are only
+    needed transiently during the initial pipeline run)."""
+    keep = {os.path.abspath(s['path']) for s in sections.values()}
+    try:
+        for name in os.listdir(work_dir):
+            path = os.path.join(work_dir, name)
+            if os.path.abspath(path) in keep:
+                continue
+            try:
+                if os.path.isfile(path) or os.path.islink(path):
+                    os.remove(path)
+                elif os.path.isdir(path):
+                    shutil.rmtree(path, ignore_errors=True)
+            except OSError as e:
+                log.warning(f'failed to prune {path}: {e}')
+    except OSError as e:
+        log.warning(f'failed to list {work_dir} for pruning: {e}')
 
 
 def _cleanup_expired_reports():
@@ -635,6 +662,15 @@ def _ensure_cleanup_thread():
         _cleanup_started = True
         t = threading.Thread(target=_cleanup_expired_reports, daemon=True)
         t.start()
+
+
+def _free_report_result(report_id: str):
+    """Drop the (large) cached result payload once it's had a fair chance to
+    be delivered — called from a one-shot timer, not the TTL sweep."""
+    with _REPORTS_LOCK:
+        entry = REPORTS.get(report_id)
+        if entry is not None:
+            entry['result'] = None
 
 
 # ── Vercel handler ────────────────────────────────────────────────────────────
@@ -694,6 +730,14 @@ class handler(BaseHTTPRequestHandler):
                 }
                 if entry.get('status') == 'done':
                     payload['result'] = entry.get('result')
+                    # The frontend only needs the full result once (it stops
+                    # polling as soon as it receives it). Free this — often
+                    # the single largest per-report memory allocation —
+                    # shortly after first delivery instead of waiting for the
+                    # full REPORT_TTL_SECONDS window.
+                    if entry.get('result') is not None and not entry.get('_free_result_scheduled'):
+                        entry['_free_result_scheduled'] = True
+                        threading.Timer(10.0, _free_report_result, args=(report_id,)).start()
                 elif entry.get('status') == 'error':
                     payload['error'] = entry.get('error')
 
@@ -830,6 +874,11 @@ def _run_pipeline(report_id: str, work_dir: str, weights: dict):
             report['process_details'] = details
 
         reporter.flat(99, 'Finalizing report')
+
+        # Free most of this report's disk (and, on tmpfs, RAM) footprint
+        # immediately — only files referenced by `sections` are needed later
+        # for on-demand /api/chunk reads.
+        _prune_work_dir(work_dir, sections)
 
         with _REPORTS_LOCK:
             entry = REPORTS.get(report_id)

--- a/api/upload.py
+++ b/api/upload.py
@@ -22,7 +22,13 @@ import urllib.parse
 from http.server import BaseHTTPRequestHandler
 
 # ── Path setup ──────────────────────────────────────────────────────────────
-WEBAPP_DIR = os.path.join(os.path.dirname(__file__), '..', 'webapp')
+# Vercel's Python runtime doesn't guarantee this file's own directory is on
+# sys.path (unlike local dev / Docker, where api/ ends up importable via
+# other means) — add it explicitly so sibling modules like lazy_details can
+# be imported below.
+API_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, API_DIR)
+WEBAPP_DIR = os.path.join(API_DIR, '..', 'webapp')
 sys.path.insert(0, WEBAPP_DIR)
 
 import plotly.io as pio

--- a/api/upload.py
+++ b/api/upload.py
@@ -544,7 +544,19 @@ def _compute_stage_weights(work_dir: str) -> dict:
 
 
 class ProgressReporter:
-    """Reports stage progress + verbose log lines into REPORTS[report_id].
+    """Streams stage progress + verbose log lines directly onto the HTTP
+    response as NDJSON lines (one JSON object per line), instead of writing
+    into a shared in-memory registry that a *separate* later request would
+    poll.
+
+    This matters because the previous design (background thread + poll via
+    GET /api/progress) relied on server state surviving across two distinct
+    HTTP requests. That's true on a persistent process (local dev, Docker),
+    but not guaranteed on classic serverless platforms like Vercel, where a
+    background thread can be frozen/killed as soon as the initiating request
+    ends, and a later poll request has no guarantee of landing on the same
+    warm instance. Streaming progress within a single request/response
+    removes that dependency entirely (see issue #88).
 
     Stages are weighted by input file size so the percent bar advances
     proportionally to how much data actually needs to be parsed. A background
@@ -553,8 +565,8 @@ class ProgressReporter:
     bar doesn't freeze while a huge file is being parsed.
     """
 
-    def __init__(self, report_id: str, weights: dict):
-        self.report_id = report_id
+    def __init__(self, emit, weights: dict):
+        self.emit = emit  # emit(percent: float|None, message: str|None, log_it: bool)
         self.weights = weights
         self.total_weight = sum(weights.values()) or 1
         self.done_weight = 0.0
@@ -564,27 +576,13 @@ class ProgressReporter:
         span = WEIGHTED_END_PCT - FLAT_START_PCT
         return FLAT_START_PCT + (weight / self.total_weight) * span
 
-    def _push(self, percent, message, log_it: bool):
-        with _REPORTS_LOCK:
-            entry = REPORTS.get(self.report_id)
-            if entry is None:
-                return
-            if percent is not None:
-                entry['percent'] = max(entry.get('percent', 0), round(percent, 1))
-            if message:
-                entry['stage'] = message
-                if log_it:
-                    entry['log'].append({'ts': time.time(), 'message': message})
-                    if len(entry['log']) > 500:
-                        entry['log'] = entry['log'][-500:]
-
     def flat(self, percent: float, message: str):
         """Set an absolute percent for a fast, unweighted early/late step."""
-        self._push(percent, message, log_it=True)
+        self.emit(percent, message, True)
 
     def begin(self, stage_key: str, message: str):
         weight = self.weights.get(stage_key, 0)
-        self._push(self._percent_for(self.done_weight), message, log_it=True)
+        self.emit(self._percent_for(self.done_weight), message, True)
 
         self._ticker_stop = threading.Event()
         stop_event = self._ticker_stop
@@ -593,7 +591,7 @@ class ProgressReporter:
             simulated = 0.0
             while not stop_event.wait(0.6):
                 simulated += (weight - simulated) * 0.15
-                self._push(self._percent_for(self.done_weight + simulated), None, log_it=False)
+                self.emit(self._percent_for(self.done_weight + simulated), None, False)
 
         threading.Thread(target=tick, daemon=True).start()
 
@@ -602,20 +600,29 @@ class ProgressReporter:
             self._ticker_stop.set()
             self._ticker_stop = None
         self.done_weight += self.weights.get(stage_key, 0)
-        self._push(self._percent_for(self.done_weight), None, log_it=False)
+        self.emit(self._percent_for(self.done_weight), None, False)
 
 
 # ── Lazy report registry ──────────────────────────────────────────────────────
 #
-# Only the handful of files actually needed to serve on-demand /api/chunk
-# requests are kept on disk (instead of the whole extracted archive) so that
-# Process Details timestamps can be fetched later. A background sweep removes
-# anything older than REPORT_TTL_SECONDS as a backstop, but most of the memory
-# footprint is released immediately: unused extracted files are deleted right
-# after the pipeline finishes, and the (potentially huge) in-memory `result`
-# JSON is dropped as soon as it has been delivered once via GET /api/progress.
-# This matters on memory-constrained hosts (small containers, Vercel
-# functions) where /tmp is often RAM-backed (tmpfs) — see issue #88.
+# The main POST /api/upload request now does all the work (extraction,
+# processing, progress streaming) itself, in a single request/response — see
+# issue #88: relying on a background thread plus a *second*, later request
+# (GET /api/progress) to observe its result depended on server state
+# surviving across two separate HTTP requests, which classic serverless
+# platforms like Vercel don't guarantee (a background thread can be
+# frozen/killed once the initiating request ends, and a later request has no
+# guarantee of landing on the same warm instance).
+#
+# REPORTS is now only used to serve on-demand GET /api/chunk requests for
+# large Process Details tables (pidstat/top/iotop), which are genuinely
+# needed *after* the main response has already been sent (the user may click
+# a different timestamp minutes later). Only the handful of files actually
+# needed for that are kept on disk (instead of the whole extracted archive);
+# a background sweep removes anything older than REPORT_TTL_SECONDS as a
+# backstop. This still has the same small residual cross-request risk on
+# serverless, but is a deliberate, bounded trade-off (see README/issue #88
+# discussion) rather than the thing that was actually crashing.
 
 REPORT_TTL_SECONDS = int(os.environ.get('REPORT_TTL_SECONDS', 15 * 60))
 REPORTS: dict = {}
@@ -664,18 +671,13 @@ def _ensure_cleanup_thread():
         t.start()
 
 
-def _free_report_result(report_id: str):
-    """Drop the (large) cached result payload once it's had a fair chance to
-    be delivered — called from a one-shot timer, not the TTL sweep."""
-    with _REPORTS_LOCK:
-        entry = REPORTS.get(report_id)
-        if entry is not None:
-            entry['result'] = None
-
-
 # ── Vercel handler ────────────────────────────────────────────────────────────
 
 class handler(BaseHTTPRequestHandler):
+    # Chunked transfer-encoding (used to stream progress in do_POST) requires
+    # HTTP/1.1; BaseHTTPRequestHandler defaults to HTTP/1.0.
+    protocol_version = 'HTTP/1.1'
+
     def log_message(self, format, *args):
         pass
 
@@ -708,43 +710,7 @@ class handler(BaseHTTPRequestHandler):
         if parsed.path == '/api/chunk':
             self._handle_chunk_request(parsed)
             return
-        if parsed.path == '/api/progress':
-            self._handle_progress_request(parsed)
-            return
         self._send_json({'error': 'not found'}, 404)
-
-    def _handle_progress_request(self, parsed):
-        qs = urllib.parse.parse_qs(parsed.query)
-        report_id = qs.get('report_id', [''])[0]
-
-        with _REPORTS_LOCK:
-            entry = REPORTS.get(report_id)
-            if not entry:
-                payload = None
-            else:
-                payload = {
-                    'status': entry.get('status', 'processing'),
-                    'percent': entry.get('percent', 0),
-                    'stage': entry.get('stage', ''),
-                    'log': entry.get('log', []),
-                }
-                if entry.get('status') == 'done':
-                    payload['result'] = entry.get('result')
-                    # The frontend only needs the full result once (it stops
-                    # polling as soon as it receives it). Free this — often
-                    # the single largest per-report memory allocation —
-                    # shortly after first delivery instead of waiting for the
-                    # full REPORT_TTL_SECONDS window.
-                    if entry.get('result') is not None and not entry.get('_free_result_scheduled'):
-                        entry['_free_result_scheduled'] = True
-                        threading.Timer(10.0, _free_report_result, args=(report_id,)).start()
-                elif entry.get('status') == 'error':
-                    payload['error'] = entry.get('error')
-
-        if payload is None:
-            self._send_json({'error': 'report not found or expired, please re-upload'}, 404)
-            return
-        self._send_json(payload)
 
     def _handle_chunk_request(self, parsed):
         qs = urllib.parse.parse_qs(parsed.query)
@@ -777,6 +743,7 @@ class handler(BaseHTTPRequestHandler):
         work_dir = None
         register_job = False
         hex_id = None
+        streaming = False
         try:
             parts = parse_cgi_multipart(self)
             file_data = parts.get('file')
@@ -810,94 +777,102 @@ class handler(BaseHTTPRequestHandler):
                         shutil.move(src, dst)
                 shutil.rmtree(sub, ignore_errors=True)
 
-            # From here on, the extracted archive is owned by REPORTS/the
-            # background pipeline thread — hand off and respond immediately
-            # so the frontend can start polling GET /api/progress instead of
-            # blocking on a multi-minute POST.
             weights = _compute_stage_weights(work_dir)
+
+            # Stream progress + the final result as newline-delimited JSON
+            # (NDJSON) within this single request/response, instead of
+            # returning immediately and handing the work off to a background
+            # thread that a *separate* later request would poll (see #88 —
+            # that design relied on server state surviving across two HTTP
+            # requests, which isn't guaranteed on serverless platforms).
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/x-ndjson')
+            self.send_header('Access-Control-Allow-Origin', '*')
+            self.send_header('Cache-Control', 'no-cache')
+            self.send_header('X-Accel-Buffering', 'no')
+            self.send_header('Transfer-Encoding', 'chunked')
+            self.end_headers()
+            streaming = True
+
+            def emit(percent, message, log_it):
+                line = {}
+                if percent is not None:
+                    line['percent'] = round(percent, 1)
+                if message:
+                    line['stage'] = message
+                    if log_it:
+                        line['log'] = message
+                if not line:
+                    return
+                self._write_chunk(json.dumps(line).encode('utf-8') + b'\n')
+
+            emit(0, 'Archive extracted, starting analysis', True)
+            reporter = ProgressReporter(emit, weights)
+
+            report: dict = {'report_id': hex_id}
+            report['metadata'] = extract_metadata(work_dir)
+
+            reporter.flat(1, 'Reading archive metadata')
+
+            sc = extract_sysconfig(work_dir)
+            if sc:
+                report['sysconfig'] = sc
+            reporter.flat(3, 'Reading system configuration')
+
+            reporter.flat(FLAT_START_PCT, 'Processing performance metrics')
+            perf = extract_performance(work_dir, reporter)
+            if perf:
+                report['performance'] = perf
+
+            activity = extract_process_activity(work_dir, reporter)
+            if activity:
+                report['process_activity'] = activity
+
+            details, sections = extract_process_details(work_dir, reporter)
+            if details:
+                report['process_details'] = details
+
+            reporter.flat(99, 'Finalizing report')
+
+            # Only files referenced by `sections` are needed later, for
+            # on-demand GET /api/chunk reads (Process Details drill-down);
+            # everything else can be freed from disk (and, on tmpfs, RAM)
+            # right away.
+            _prune_work_dir(work_dir, sections)
             _ensure_cleanup_thread()
             with _REPORTS_LOCK:
                 REPORTS[hex_id] = {
                     'created': time.time(),
                     'work_dir': work_dir,
-                    'status': 'processing',
-                    'percent': 0,
-                    'stage': 'Starting…',
-                    'log': [{'ts': time.time(), 'message': 'Archive extracted, starting analysis'}],
-                    'sections': {},
+                    'sections': sections,
                 }
             register_job = True
 
-            t = threading.Thread(target=_run_pipeline, args=(hex_id, work_dir, weights), daemon=True)
-            t.start()
-
-            self._send_json({'report_id': hex_id}, 202)
+            self._write_chunk(json.dumps({'percent': 100, 'stage': 'Done', 'result': report}).encode('utf-8') + b'\n')
+            self._write_chunk(b'')
 
         except Exception as e:
             import traceback
             log.error(traceback.format_exc())
-            self._send_json({'error': f'Processing failed: {e}'}, 500)
+            if streaming:
+                try:
+                    self._write_chunk(json.dumps({'error': f'Processing failed: {e}'}).encode('utf-8') + b'\n')
+                    self._write_chunk(b'')
+                except Exception:
+                    pass
+            else:
+                self._send_json({'error': f'Processing failed: {e}'}, 500)
         finally:
-            # If the job was never registered (e.g. failed before hand-off),
-            # this request still owns work_dir and must clean it up itself.
+            # If the job was never registered (e.g. failed before it could be
+            # pruned/handed off for /api/chunk), this request still owns
+            # work_dir and must clean it up itself.
             if not register_job and work_dir and os.path.exists(work_dir):
                 shutil.rmtree(work_dir, ignore_errors=True)
 
-
-def _run_pipeline(report_id: str, work_dir: str, weights: dict):
-    """Runs the full extraction pipeline in a background thread, updating
-    REPORTS[report_id] with progress as it goes and the final result/error
-    when done."""
-    reporter = ProgressReporter(report_id, weights)
-    try:
-        report: dict = {'report_id': report_id}
-
-        reporter.flat(1, 'Reading archive metadata')
-        report['metadata'] = extract_metadata(work_dir)
-
-        reporter.flat(3, 'Reading system configuration')
-        sc = extract_sysconfig(work_dir)
-        if sc:
-            report['sysconfig'] = sc
-
-        reporter.flat(FLAT_START_PCT, 'Processing performance metrics')
-        perf = extract_performance(work_dir, reporter)
-        if perf:
-            report['performance'] = perf
-
-        activity = extract_process_activity(work_dir, reporter)
-        if activity:
-            report['process_activity'] = activity
-
-        details, sections = extract_process_details(work_dir, reporter)
-        if details:
-            report['process_details'] = details
-
-        reporter.flat(99, 'Finalizing report')
-
-        # Free most of this report's disk (and, on tmpfs, RAM) footprint
-        # immediately — only files referenced by `sections` are needed later
-        # for on-demand /api/chunk reads.
-        _prune_work_dir(work_dir, sections)
-
-        with _REPORTS_LOCK:
-            entry = REPORTS.get(report_id)
-            if entry is not None:
-                entry['status'] = 'done'
-                entry['percent'] = 100
-                entry['stage'] = 'Done'
-                entry['result'] = report
-                entry['sections'] = sections
-                entry['log'].append({'ts': time.time(), 'message': 'Report ready'})
-
-    except Exception as e:
-        import traceback
-        log.error(traceback.format_exc())
-        with _REPORTS_LOCK:
-            entry = REPORTS.get(report_id)
-            if entry is not None:
-                entry['status'] = 'error'
-                entry['error'] = str(e)
-                entry['log'].append({'ts': time.time(), 'message': f'Error: {e}'})
-        # Nothing to serve for a failed job — release the extracted archive.
-        shutil.rmtree(work_dir, ignore_errors=True)
+    def _write_chunk(self, data: bytes):
+        """Write one HTTP chunked-transfer-encoding frame and flush it
+        immediately so the client sees progress as it happens."""
+        self.wfile.write(b'%x\r\n' % len(data))
+        self.wfile.write(data)
+        self.wfile.write(b'\r\n')
+        self.wfile.flush()

--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import type { ReportData } from '../types/report';
 
 export interface LogLine {
@@ -12,70 +12,82 @@ type UploadState =
   | { status: 'done'; data: ReportData }
   | { status: 'error'; message: string };
 
-const POLL_INTERVAL_MS = 800;
-
+// The full response body is a single request that streams newline-delimited
+// JSON (NDJSON) progress lines, ending with a final line containing the full
+// report (or an error). This avoids depending on server-side state surviving
+// across two separate HTTP requests (upload + poll), which isn't guaranteed
+// on serverless platforms like Vercel — see issue #88.
 export function useUpload() {
   const [state, setState] = useState<UploadState>({ status: 'idle' });
-  const pollTimer = useRef<number | null>(null);
-
-  function stopPolling() {
-    if (pollTimer.current !== null) {
-      window.clearTimeout(pollTimer.current);
-      pollTimer.current = null;
-    }
-  }
-
-  function pollProgress(reportId: string) {
-    pollTimer.current = window.setTimeout(async () => {
-      try {
-        const res = await fetch(`/api/progress?report_id=${encodeURIComponent(reportId)}`);
-        const json = await res.json();
-        if (!res.ok || json.error) {
-          setState({ status: 'error', message: json.error ?? `HTTP ${res.status}` });
-          return;
-        }
-        if (json.status === 'done') {
-          setState({ status: 'done', data: json.result });
-          return;
-        }
-        if (json.status === 'error') {
-          setState({ status: 'error', message: json.error ?? 'Processing failed' });
-          return;
-        }
-        setState({
-          status: 'uploading',
-          percent: json.percent ?? 0,
-          stage: json.stage ?? '',
-          log: json.log ?? [],
-        });
-        pollProgress(reportId);
-      } catch (e) {
-        setState({ status: 'error', message: (e as Error).message });
-      }
-    }, POLL_INTERVAL_MS);
-  }
 
   async function upload(file: File) {
-    stopPolling();
     setState({ status: 'uploading', percent: 0, stage: 'Uploading archive…', log: [] });
     const form = new FormData();
     form.append('file', file);
 
+    let log: LogLine[] = [];
+
     try {
       const res = await fetch('/api/upload', { method: 'POST', body: form });
-      const json = await res.json();
-      if (!res.ok || json.error) {
-        setState({ status: 'error', message: json.error ?? `HTTP ${res.status}` });
+      if (!res.ok || !res.body) {
+        let message = `HTTP ${res.status}`;
+        try {
+          const json = await res.json();
+          message = json.error ?? message;
+        } catch {
+          // response wasn't JSON (e.g. platform error page) — keep the HTTP status message
+        }
+        setState({ status: 'error', message });
         return;
       }
-      pollProgress(json.report_id);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let newlineIdx: number;
+        while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newlineIdx).trim();
+          buffer = buffer.slice(newlineIdx + 1);
+          if (!line) continue;
+
+          let json: any;
+          try {
+            json = JSON.parse(line);
+          } catch {
+            continue; // ignore malformed/partial line, shouldn't normally happen
+          }
+
+          if (json.error) {
+            setState({ status: 'error', message: json.error });
+            return;
+          }
+          if (json.result) {
+            setState({ status: 'done', data: json.result });
+            return;
+          }
+          if (json.log) {
+            log = [...log, { ts: Date.now(), message: json.log }];
+          }
+          setState((prev) => ({
+            status: 'uploading',
+            percent: json.percent ?? (prev.status === 'uploading' ? prev.percent : 0),
+            stage: json.stage ?? (prev.status === 'uploading' ? prev.stage : ''),
+            log,
+          }));
+        }
+      }
     } catch (e) {
       setState({ status: 'error', message: (e as Error).message });
     }
   }
 
   function reset() {
-    stopPolling();
     setState({ status: 'idle' });
   }
 


### PR DESCRIPTION
## Fixes #88

### Real root cause (confirmed on the live production deployment)
Production has been fully broken for **every single upload**, regardless of archive size, since the lazy per-timestamp loading feature was merged. `api/upload.py` does `import lazy_details`, which relies on the file's own directory being on `sys.path` — true locally and in Docker, but **not guaranteed on Vercel's Python runtime**. Every request has been crashing at import time with:

```
ModuleNotFoundError: No module named 'lazy_details'
```

which Vercel returns as a generic `FUNCTION_INVOCATION_FAILED` HTML error page (not JSON) — this is exactly what produces the `JSON.parse: unexpected character at line 1 column 1` error reported in #88, since the frontend calls `res.json()` on a non-JSON body.

Confirmed directly by curling the current production endpoint and pulling the Vercel function logs, which showed the traceback above.

**Fix:** explicitly add `api/upload.py`'s own directory to `sys.path` before importing `lazy_details`. Verified: uploading `examples/test.tar.gz` against a fresh preview deployment built from this branch now succeeds end-to-end (previously 500'd).

### Additional hardening in this PR (found while investigating, real but not the trigger)
The same in-memory `REPORTS` design that powers progress reporting had two related but separate issues, both still worth fixing regardless of the import bug above:

1. **Unbounded `/tmp` + in-memory report retention** — extracted archive files and the full report JSON were retained on disk/RAM for a fixed 15-minute TTL even when no longer needed, which could grow usage roughly unbounded under sustained traffic on memory-constrained hosts. Fixed via `_prune_work_dir()` (deletes files not needed for later `/api/chunk` reads immediately after the pipeline finishes) and a configurable `REPORT_TTL_SECONDS`.

2. **Cross-request in-memory state dependency for progress reporting** — `POST /api/upload` previously spawned a background thread and returned immediately, with a *separate* later request (`GET /api/progress`) polling shared in-memory job state. That's safe on a persistent process (local dev, Docker) but not guaranteed on classic serverless platforms — a background thread has no guarantee of surviving past the response, and a later poll has no guarantee of landing on the same warm instance. Fixed by doing all the work in the single `POST /api/upload` request/response, streaming progress as newline-delimited JSON (NDJSON) via HTTP chunked transfer-encoding, ending with the full report as the last line. No background thread, no `GET /api/progress` route needed.

`REPORTS` is still used, unchanged in spirit, to serve on-demand `GET /api/chunk` requests for large Process Details tables (pidstat/top/iotop) needed *after* the main response — a deliberate, bounded trade-off, not something this PR needed to change.

### Verification
- Reproduced the real crash by curling current production (`https://linuxaioperf.vercel.app/api/upload`) and pulling `vercel logs`/dashboard function logs — confirmed the `ModuleNotFoundError` traceback.
- Deployed this branch to a fresh Vercel preview and confirmed uploading `examples/test.tar.gz` now succeeds end-to-end (streamed progress + final report render correctly).
- Verified locally (dev-api.py, Vite proxy, and `docker-compose.v3.yml`/`Dockerfile.v3` which share the same handler) with both `examples/test.tar.gz` and a real ~125MB archive.
- Verified `/api/chunk` still serves correct data from the pruned `work_dir` for all 5 process-detail sections.
- Stress-tested the OOM fix locally: RSS growth per 20-upload batch dropped from +203MB to +64MB; per-report disk footprint dropped from 4.9MB to ~1.5MB.
- `tsc --noEmit` passes.
