### PR TITLE
Fix high-res disk latency boxplot showing only max value (#87)

### DIFF
--- a/webapp/domains/perfanalysis/disk/diskhighres.py
+++ b/webapp/domains/perfanalysis/disk/diskhighres.py
@@ -79,20 +79,24 @@ class DiskHighResProcessor(BaseDataProcessor):
             (sectors_read_delta + sectors_write_delta) * 512 / 1024 / 1024
         )
 
-        # Calculate latency (in milliseconds)
+        # Calculate latency (in milliseconds). Use NaN (not 0) when no I/O
+        # completed in this sample window, since 0 is a misleadingly "real"
+        # latency value that skews percentile-based views (e.g. the latency
+        # boxplot's quartiles get dragged down to 0 by mostly-idle windows,
+        # see issue #87) -- NaN is excluded from percentile/box statistics
+        # and time-series line plots naturally render it as a gap.
         read_time_delta = device_data['Time_Reading'].diff()
         write_time_delta = device_data['Time_Writing'].diff()
 
-        # Avoid division by zero
         read_latency = np.where(
             reads_delta > 0,
             read_time_delta / reads_delta,
-            0
+            np.nan
         )
         write_latency = np.where(
             writes_delta > 0,
             write_time_delta / writes_delta,
-            0
+            np.nan
         )
 
         device_data['Read_Latency'] = read_latency
@@ -133,16 +137,16 @@ class DiskHighResProcessor(BaseDataProcessor):
         read_time_delta = resampled['Time_Reading'].diff()
         write_time_delta = resampled['Time_Writing'].diff()
 
-        # Avoid division by zero
+        # Avoid division by zero → use NaN (see note in _calculate_rates)
         resampled['Read_Latency'] = np.where(
             reads_delta > 0,
             read_time_delta / reads_delta,
-            0
+            np.nan
         )
         resampled['Write_Latency'] = np.where(
             writes_delta > 0,
             write_time_delta / writes_delta,
-            0
+            np.nan
         )
 
         return resampled


### PR DESCRIPTION
## Fixes #87

Targets `release/v2.3.3` instead of `main` — this fix will be bundled with the next metrics fix into a single release PR to `main`.

### Root cause
Read/write latency is calculated as `time_delta / count_delta` per 50ms sample. When no I/O completed in a given window (very common at 50ms resolution — devices are idle most of the time), the code set latency to `0` instead of leaving it undefined. Idle windows vastly outnumber active ones, so the 25th/50th/75th percentiles used to build the boxplot were dragged down to 0 by this flood of fake zeros, leaving only genuine latency spikes visible as outlier points/whiskers — exactly the "only max is shown, everything else is 0" symptom in #87.

### Fix
Use `NaN` (not `0`) for windows with no completed I/O, in both `_calculate_rates` (50ms resolution) and `_resample_device_data` (1s avg resolution). NaN is correctly excluded from percentile/box statistics by Plotly (client and server side), and time-series line plots naturally render it as a gap rather than a misleading flat-zero segment.

### Verification
Verified against a real ~125MB archive, both via the processor directly and through the full API pipeline: boxplot quartiles are now real, meaningful percentiles (e.g. `sdb Read (50ms): q1=26.6, median=42.8, q3=70.3, max=282.5`) instead of being collapsed to 0, and devices/directions with genuinely zero I/O correctly produce an empty box instead of a fake spike at 0.
