### PR TITLE
Fix disk throughput axis unit ambiguity (#89)

### DIFF
--- a/webapp/core/base.py
+++ b/webapp/core/base.py
@@ -142,7 +142,9 @@ class BaseDataProcessor(ABC):
             raise DataProcessorError(f"Failed to write filtered data: {e}")
 
     def get_common_plot_layout(self, title: str, x_title: str = "Timestamp",
-                               y_title: str = "Value") -> Dict[str, Any]:
+                               y_title: str = "Value",
+                               disable_axis_si_prefix: bool = False
+                               ) -> Dict[str, Any]:
         """
         Get common plot layout configuration.
 
@@ -150,11 +152,17 @@ class BaseDataProcessor(ABC):
             title: Plot title
             x_title: X-axis title
             y_title: Y-axis title
+            disable_axis_si_prefix: When True, prevents Plotly from
+                applying its own SI-prefix abbreviation (e.g. "15k") to
+                y-axis tick labels. Useful when the underlying values are
+                already expressed in a scaled unit (e.g. KB/s), where
+                Plotly's auto-abbreviation would stack ambiguously with
+                the unit already baked into the axis title.
 
         Returns:
             Layout configuration dictionary
         """
-        return {
+        layout = {
             'template': "seaborn",
             'title': title,
             'xaxis_title': x_title,
@@ -178,6 +186,56 @@ class BaseDataProcessor(ABC):
                 'tickformat': "%Y-%m-%d %H:%M:%S"
             }
         }
+
+        if disable_axis_si_prefix:
+            layout['yaxis'] = {
+                'exponentformat': "none",
+                'separatethousands': True
+            }
+
+        return layout
+
+    @staticmethod
+    def scale_throughput_series(
+        series: pd.Series, base_unit: str = "KB"
+    ) -> Tuple[pd.Series, str]:
+        """
+        Rescale a throughput series (already expressed in ``base_unit``
+        per second) to the largest unit that keeps values in a
+        human-readable range, avoiding ambiguity with Plotly's automatic
+        SI-prefix axis tick abbreviation (e.g. a raw "15000 KB/s" value
+        being displayed on the axis as just "15k", which looks like
+        "15 thousand KB/s" rather than the correct "15 MB/s").
+
+        Args:
+            series: Numeric series already expressed in ``base_unit``/s.
+            base_unit: The unit the input series is already expressed in
+                (defaults to "KB", matching iostat's kB/s columns).
+
+        Returns:
+            Tuple of (rescaled_series, unit_label) where unit_label is
+            e.g. "KB/s", "MB/s" or "GB/s".
+        """
+        units = ["KB", "MB", "GB", "TB"]
+        try:
+            start_idx = units.index(base_unit)
+        except ValueError:
+            start_idx = 0
+
+        max_value = series.abs().max()
+        scale = 0
+        # Each step up divides by 1024, keeping typical values below 1024
+        while (
+            pd.notna(max_value)
+            and max_value >= 1024
+            and start_idx + scale < len(units) - 1
+        ):
+            max_value /= 1024
+            scale += 1
+
+        scaled_series = series / (1024 ** scale) if scale else series
+        unit_label = f"{units[start_idx + scale]}/s"
+        return scaled_series, unit_label
 
     def process(self) -> Tuple[pd.DataFrame, List[go.Figure]]:
         """

--- a/webapp/domains/perfanalysis/disk/diskiostat.py
+++ b/webapp/domains/perfanalysis/disk/diskiostat.py
@@ -11,6 +11,12 @@ import plotly.graph_objects as go
 
 from core.base import BaseDataProcessor, DataProcessorError
 
+# iostat columns already expressed in KB/s. Plotly's default axis tick
+# renderer applies its own SI-prefix abbreviation (e.g. "15k") which is
+# ambiguous when stacked on top of an already-scaled "kB/s" unit, so
+# these are rescaled to the most human-readable unit before plotting.
+THROUGHPUT_COLUMNS = {'rkB/s', 'wkB/s', 'dkB/s'}
+
 
 class DiskIostatProcessor(BaseDataProcessor):
     """
@@ -113,10 +119,17 @@ class DiskIostatProcessor(BaseDataProcessor):
                         )
                     )
 
-                # Apply layout
+                # Apply layout. This chart mixes metrics with different
+                # units (KB/s, requests/s, ms, %) on one shared axis, so
+                # we cannot rescale a single unit here - instead we
+                # disable Plotly's automatic SI-prefix tick abbreviation
+                # (e.g. "15k") which otherwise looks ambiguous stacked on
+                # top of units already baked into each metric name (see
+                # issue #89). Hover tooltips still show exact values.
                 layout = self.get_common_plot_layout(
                     title=f'Disk Metrics - {device}',
-                    y_title='Value'
+                    y_title='Value',
+                    disable_axis_si_prefix=True
                 )
                 fig.update_layout(**layout)
 

--- a/webapp/domains/perfanalysis/disk/diskmetrics.py
+++ b/webapp/domains/perfanalysis/disk/diskmetrics.py
@@ -11,6 +11,12 @@ import plotly.graph_objects as go
 
 from core.base import BaseDataProcessor, DataProcessorError
 
+# iostat columns already expressed in KB/s. Plotly's default axis tick
+# renderer applies its own SI-prefix abbreviation (e.g. "15k") which is
+# ambiguous when stacked on top of an already-scaled "kB/s" unit, so
+# these are rescaled to the most human-readable unit before plotting.
+THROUGHPUT_COLUMNS = {'rkB/s', 'wkB/s', 'dkB/s'}
+
 
 class DiskMetricsProcessor(BaseDataProcessor):
     """
@@ -98,11 +104,32 @@ class DiskMetricsProcessor(BaseDataProcessor):
             for metric in metric_cols:
                 fig = go.Figure()
 
+                is_throughput = metric in THROUGHPUT_COLUMNS
+                unit_label = metric
+                divisor = 1
+
+                if is_throughput:
+                    # Determine a single shared unit scale for this metric
+                    # across all devices, based on the overall max value,
+                    # so every device trace on the plot uses the same
+                    # human-readable unit (e.g. all in MB/s).
+                    all_values = pd.to_numeric(df[metric], errors='coerce')
+                    _, unit_label = self.scale_throughput_series(
+                        all_values, base_unit="KB")
+                    unit_scale = {
+                        "KB/s": 1, "MB/s": 1024,
+                        "GB/s": 1024 ** 2, "TB/s": 1024 ** 3
+                    }
+                    divisor = unit_scale.get(unit_label, 1)
+
                 # Add traces for each device
                 for device in device_labels.unique():
                     device_data = df[df[df.columns[1]] == device]
                     x = device_data[device_data.columns[0]]  # Timestamp
                     y = pd.to_numeric(device_data[metric])   # Metric values
+                    if divisor != 1:
+                        y = y / divisor
+
                     fig.add_trace(
                         go.Scatter(
                             x=x, y=y, mode='lines',
@@ -110,10 +137,16 @@ class DiskMetricsProcessor(BaseDataProcessor):
                         )
                     )
 
-                # Apply layout
+                # Apply layout. For throughput metrics the axis title now
+                # reflects the actual rescaled unit (e.g. "wkB/s (MB/s)")
+                # and Plotly's SI-prefix tick abbreviation is disabled to
+                # avoid stacking ambiguously on top of it (see issue #89).
+                y_title = f"{metric} ({unit_label})" if is_throughput \
+                    else metric
                 layout = self.get_common_plot_layout(
                     title=f'Disk {metric} - All Devices',
-                    y_title=metric
+                    y_title=y_title,
+                    disable_axis_si_prefix=is_throughput
                 )
                 fig.update_layout(**layout)
 


### PR DESCRIPTION
## Problem
Disk throughput plots (`wkB/s`, `rkB/s`, `dkB/s` from iostat) show Plotly's default SI-prefix axis tick abbreviation (e.g. "15k") stacked on top of a title that already says the unit is `kB/s`. Users read "15k" next to "wkB/s" as ambiguous — is it 15 thousand KB/s (i.e. 15 MB/s) or something else?

## Fix
- **Disk Device/Metrics view** (`diskmetrics.py`, per-metric across devices): rescale each throughput metric to the most appropriate human-readable unit (KB/MB/GB per second) based on its value range, and label the axis with the real unit, e.g. `wkB/s (MB/s)`.
- **Disk Metrics/Device view** (`diskiostat.py`, per-device across metrics): this view mixes several different units on one axis (KB/s, req/s, ms, %), so per-metric rescaling isn't possible. Instead, Plotly's automatic SI-prefix tick abbreviation is disabled so raw values render without ambiguity. Hover tooltips still show exact values.
- `base.py`: added `disable_axis_si_prefix` option to `get_common_plot_layout()` and a `scale_throughput_series()` helper.

## Verification
Ran the fix against `examples/test.tar.gz` via the local dev API. Confirmed in the streamed report JSON:
- `wkB/s` plot now correctly shows y-axis title `wkB/s (MB/s)` with max device value ~25 MB/s (raw was ~25,000 KB/s).
- `dkB/s` plot rescaled to GB/s where appropriate.
- Per-device view now sets `exponentformat: none` to avoid the ambiguous "15k" style ticks.

Fixes #89