### PR TITLE
feat: support long Azure analyses on local storage

### DIFF
--- a/.github/workflows/docker-react-publish.yml
+++ b/.github/workflows/docker-react-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/azure-react-webapp
 
 jobs:
   build-and-push:
@@ -27,8 +28,11 @@ jobs:
         with:
           images: samuelmatildes/linuxaioperf-react
           tags: |
-            type=raw,value=latest
-            type=sha,prefix=,format=short
+            # main retains the existing public latest tag.
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # The feature branch has its own readable tag and an immutable SHA tag.
+            type=raw,value=azure-feature,enable=${{ github.ref == 'refs/heads/chore/azure-react-webapp' }}
+            type=raw,value=${{ github.sha }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -40,3 +44,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy-azure-feature:
+    name: Deploy published feature image to Azure
+    needs: build-and-push
+    # The deployment stays entirely on the feature branch. main continues to
+    # build and publish its existing latest image without any Azure deployment.
+    if: github.ref == 'refs/heads/chore/azure-react-webapp'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy the immutable image already published by the build job
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_REACT_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_REACT_WEBAPP_PUBLISH_PROFILE }}
+          images: samuelmatildes/linuxaioperf-react:${{ github.sha }}

--- a/Dockerfile.v3
+++ b/Dockerfile.v3
@@ -31,6 +31,9 @@ RUN mkdir -p /tmp/linuxaio && chmod 777 /tmp/linuxaio
 EXPOSE 8000
 
 ENV PORT=8000
+# Azure's persistent container can keep analysis jobs on its local filesystem.
+# Vercel does not set this flag and retains the synchronous serverless route.
+ENV LOCAL_ASYNC_ANALYSIS=1
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8000/ || exit 1

--- a/api/async_jobs.py
+++ b/api/async_jobs.py
@@ -1,0 +1,55 @@
+"""Ephemeral in-process state for analysis jobs on persistent containers."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+
+
+class AnalysisJobs:
+    """Thread-safe job state.  Deliberately local to one container instance."""
+
+    def __init__(self):
+        self._jobs: dict[str, dict] = {}
+        self._lock = threading.Lock()
+
+    def start(self) -> str:
+        job_id = secrets.token_hex(16)
+        with self._lock:
+            self._jobs[job_id] = {
+                'status': 'processing',
+                'percent': 0,
+                'stage': 'Archive extracted, starting analysis',
+                'log': [],
+                'created': time.time(),
+            }
+        return job_id
+
+    def progress(self, job_id: str, percent: float | None, stage: str | None) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job or job['status'] != 'processing':
+                return
+            if percent is not None:
+                job['percent'] = round(percent, 1)
+            if stage:
+                job['stage'] = stage
+                job['log'].append({'ts': int(time.time() * 1000), 'message': stage})
+
+    def complete(self, job_id: str, result: dict) -> None:
+        with self._lock:
+            job = self._jobs[job_id]
+            job.update({'status': 'done', 'percent': 100, 'stage': 'Done', 'result': result})
+
+    def fail(self, job_id: str, message: str) -> None:
+        with self._lock:
+            job = self._jobs[job_id]
+            job.update({'status': 'error', 'stage': 'Failed', 'error': message})
+
+    def get(self, job_id: str) -> dict | None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            return {key: value for key, value in job.items() if key != 'created'}

--- a/api/upload.py
+++ b/api/upload.py
@@ -22,6 +22,11 @@ import urllib.parse
 from functools import wraps
 from http.server import BaseHTTPRequestHandler
 
+try:  # package import on Vercel
+    from .async_jobs import AnalysisJobs
+except ImportError:  # top-level import from scripts/serve.py
+    from async_jobs import AnalysisJobs
+
 # ── Path setup ──────────────────────────────────────────────────────────────
 # Vercel's Python runtime doesn't guarantee this file's own directory is on
 # sys.path (unlike local dev / Docker, where api/ ends up importable via
@@ -646,9 +651,11 @@ class ProgressReporter:
 # discussion) rather than the thing that was actually crashing.
 
 REPORT_TTL_SECONDS = int(os.environ.get('REPORT_TTL_SECONDS', 15 * 60))
+LOCAL_ASYNC_ANALYSIS = os.environ.get('LOCAL_ASYNC_ANALYSIS') == '1'
 REPORTS: dict = {}
 _REPORTS_LOCK = threading.Lock()
 _cleanup_started = False
+ASYNC_JOBS = AnalysisJobs()
 
 
 def _prune_work_dir(work_dir: str, sections: dict):
@@ -692,6 +699,60 @@ def _ensure_cleanup_thread():
         t.start()
 
 
+def _run_local_analysis(job_id: str, report_id: str, work_dir: str, weights: dict) -> None:
+    """Run the long pipeline after Azure has returned the upload response.
+
+    This is used only by the persistent container image.  Vercel keeps the
+    synchronous NDJSON route because a serverless invocation cannot own a
+    background thread once its HTTP response has ended.
+    """
+    registered = False
+    try:
+        def emit(percent, message, log_it):
+            ASYNC_JOBS.progress(job_id, percent, message if log_it else None)
+
+        reporter = ProgressReporter(emit, weights)
+        report: dict = {'report_id': report_id}
+        report['metadata'] = extract_metadata(work_dir)
+        reporter.flat(1, 'Reading archive metadata')
+
+        sc = extract_sysconfig(work_dir)
+        if sc:
+            report['sysconfig'] = sc
+        reporter.flat(3, 'Reading system configuration')
+
+        reporter.flat(FLAT_START_PCT, 'Processing performance metrics')
+        perf = extract_performance(work_dir, reporter)
+        if perf:
+            report['performance'] = perf
+
+        activity = extract_process_activity(work_dir, reporter)
+        if activity:
+            report['process_activity'] = activity
+
+        details, sections = extract_process_details(work_dir, reporter)
+        if details:
+            report['process_details'] = details
+        reporter.flat(99, 'Finalizing report')
+
+        _prune_work_dir(work_dir, sections)
+        _ensure_cleanup_thread()
+        with _REPORTS_LOCK:
+            REPORTS[report_id] = {
+                'created': time.time(),
+                'work_dir': work_dir,
+                'sections': sections,
+            }
+        registered = True
+        ASYNC_JOBS.complete(job_id, report)
+    except Exception as exc:
+        log.exception('local async analysis failed')
+        ASYNC_JOBS.fail(job_id, f'Processing failed: {exc}')
+    finally:
+        if not registered:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
 # ── Vercel handler ────────────────────────────────────────────────────────────
 
 class handler(BaseHTTPRequestHandler):
@@ -728,10 +789,21 @@ class handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == '/api/job':
+            self._handle_job_request(parsed)
+            return
         if parsed.path == '/api/chunk':
             self._handle_chunk_request(parsed)
             return
         self._send_json({'error': 'not found'}, 404)
+
+    def _handle_job_request(self, parsed):
+        job_id = urllib.parse.parse_qs(parsed.query).get('job_id', [''])[0]
+        job = ASYNC_JOBS.get(job_id)
+        if not job:
+            self._send_json({'error': 'job not found or lost after a container restart'}, 404)
+            return
+        self._send_json(job)
 
     def _handle_chunk_request(self, parsed):
         qs = urllib.parse.parse_qs(parsed.query)
@@ -799,6 +871,18 @@ class handler(BaseHTTPRequestHandler):
                 shutil.rmtree(sub, ignore_errors=True)
 
             weights = _compute_stage_weights(work_dir)
+
+            if LOCAL_ASYNC_ANALYSIS:
+                job_id = ASYNC_JOBS.start()
+                worker = threading.Thread(
+                    target=_run_local_analysis,
+                    args=(job_id, hex_id, work_dir, weights),
+                    daemon=True,
+                )
+                worker.start()
+                register_job = True
+                self._send_json({'job_id': job_id, 'status': 'processing'}, 202)
+                return
 
             # Stream progress + the final result as newline-delimited JSON
             # (NDJSON) within this single request/response, instead of

--- a/api/upload.py
+++ b/api/upload.py
@@ -19,6 +19,7 @@ import gzip
 import threading
 import time
 import urllib.parse
+from functools import wraps
 from http.server import BaseHTTPRequestHandler
 
 # ── Path setup ──────────────────────────────────────────────────────────────
@@ -27,6 +28,7 @@ from http.server import BaseHTTPRequestHandler
 # other means) — add it explicitly so sibling modules like lazy_details can
 # be imported below.
 API_DIR = os.path.dirname(os.path.abspath(__file__))
+APP_ROOT = os.path.abspath(os.path.join(API_DIR, '..'))
 sys.path.insert(0, API_DIR)
 WEBAPP_DIR = os.path.join(API_DIR, '..', 'webapp')
 sys.path.insert(0, WEBAPP_DIR)
@@ -43,9 +45,19 @@ from domains.procinfo.pidstat.pidstatmem import pidstatmem_extract_header_line
 from domains.sysconfig.lvm.lvmviz import parse_pvs, parse_vgs, parse_lvs
 
 import lazy_details
+from workdir import working_directory
 
 logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger('api.upload')
+
+
+def _in_upload_work_dir(function):
+    """Serialize processors that require relative paths inside an upload."""
+    @wraps(function)
+    def wrapped(work_dir, *args, **kwargs):
+        with working_directory(work_dir, restore_to=APP_ROOT):
+            return function(work_dir, *args, **kwargs)
+    return wrapped
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -139,6 +151,7 @@ def extract_metadata(work_dir: str) -> dict:
 
 # ── System Configuration ─────────────────────────────────────────────────────
 
+@_in_upload_work_dir
 def extract_sysconfig(work_dir: str) -> dict:
     sc = {}
 
@@ -217,6 +230,7 @@ def extract_sysconfig(work_dir: str) -> dict:
 
 # ── Performance (time-series charts) ─────────────────────────────────────────
 
+@_in_upload_work_dir
 def extract_performance(work_dir: str, progress: 'ProgressReporter | None' = None) -> dict:
     orig = os.getcwd()
     os.chdir(work_dir)
@@ -298,6 +312,7 @@ def _top_consumers_to_figs(data: dict, metric_keys: list[tuple[str, str]]) -> li
     return figs
 
 
+@_in_upload_work_dir
 def extract_process_activity(work_dir: str, progress: 'ProgressReporter | None' = None) -> dict:
     orig = os.getcwd()
     os.chdir(work_dir)

--- a/api/workdir.py
+++ b/api/workdir.py
@@ -1,0 +1,28 @@
+"""Safe, process-wide working-directory changes for upload processors."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import os
+import threading
+from collections.abc import Iterator
+
+
+_CWD_LOCK = threading.RLock()
+
+
+@contextmanager
+def working_directory(path: str, *, restore_to: str) -> Iterator[None]:
+    """Run a block in ``path`` and always restore a known, existing directory.
+
+    ``os.chdir`` is process-global, so the lock prevents parallel HTTP requests
+    from observing each other's temporary upload directory.  ``restore_to`` is
+    explicit rather than derived with ``os.getcwd()`` because a failed upload
+    may have already deleted the current directory.
+    """
+    with _CWD_LOCK:
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(restore_to)

--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -20,6 +20,31 @@ type UploadState =
 export function useUpload() {
   const [state, setState] = useState<UploadState>({ status: 'idle' });
 
+  async function waitForLocalJob(jobId: string, log: LogLine[]) {
+    while (true) {
+      await new Promise((resolve) => window.setTimeout(resolve, 1000));
+      const res = await fetch(`/api/job?job_id=${encodeURIComponent(jobId)}`);
+      const job = await res.json();
+      if (!res.ok || job.error) {
+        setState({ status: 'error', message: job.error ?? `HTTP ${res.status}` });
+        return;
+      }
+      if (job.stage && log.at(-1)?.message !== job.stage) {
+        log = [...log, { ts: Date.now(), message: job.stage }];
+      }
+      setState({
+        status: 'uploading',
+        percent: job.percent ?? 0,
+        stage: job.stage ?? 'Processing archive…',
+        log,
+      });
+      if (job.status === 'done') {
+        setState({ status: 'done', data: job.result });
+        return;
+      }
+    }
+  }
+
   async function upload(file: File) {
     setState({ status: 'uploading', percent: 0, stage: 'Uploading archive…', log: [] });
     const form = new FormData();
@@ -38,6 +63,12 @@ export function useUpload() {
           // response wasn't JSON (e.g. platform error page) — keep the HTTP status message
         }
         setState({ status: 'error', message });
+        return;
+      }
+
+      if (res.status === 202) {
+        const job = await res.json();
+        await waitForLocalJob(job.job_id, log);
         return;
       }
 

--- a/tests/test_async_jobs.py
+++ b/tests/test_async_jobs.py
@@ -1,0 +1,28 @@
+"""Tests for in-container analysis job state used by Azure mode."""
+
+import unittest
+
+from api.async_jobs import AnalysisJobs
+
+
+class AnalysisJobsTests(unittest.TestCase):
+    def test_progress_and_result_are_available_after_a_job_is_started(self):
+        jobs = AnalysisJobs()
+        job_id = jobs.start()
+
+        jobs.progress(job_id, 42.5, 'Processing CPU')
+        jobs.complete(job_id, {'report_id': job_id})
+
+        state = jobs.get(job_id)
+        self.assertEqual(state['status'], 'done')
+        self.assertEqual(state['percent'], 100)
+        self.assertEqual(state['stage'], 'Done')
+        self.assertEqual(state['result'], {'report_id': job_id})
+        self.assertEqual(state['log'][-1]['message'], 'Processing CPU')
+
+    def test_unknown_job_is_not_reported_as_running(self):
+        self.assertIsNone(AnalysisJobs().get('missing'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -1,0 +1,50 @@
+"""Regression tests for process-wide working-directory handling."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from api.workdir import working_directory
+
+
+class WorkingDirectoryTests(unittest.TestCase):
+    def setUp(self):
+        self.anchor = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.anchor)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.anchor, ignore_errors=True)
+
+    def test_restores_anchor_when_body_raises(self):
+        work_dir = tempfile.mkdtemp()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "upload interrupted"):
+                with working_directory(work_dir, restore_to=self.anchor):
+                    self.assertEqual(os.getcwd(), work_dir)
+                    raise RuntimeError("upload interrupted")
+            self.assertEqual(os.getcwd(), self.anchor)
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    def test_recovers_when_previous_working_directory_was_deleted(self):
+        deleted_dir = tempfile.mkdtemp()
+        work_dir = tempfile.mkdtemp()
+        try:
+            os.chdir(deleted_dir)
+            shutil.rmtree(deleted_dir)
+            with self.assertRaises(FileNotFoundError):
+                os.getcwd()
+
+            with working_directory(work_dir, restore_to=self.anchor):
+                self.assertEqual(os.getcwd(), work_dir)
+
+            self.assertEqual(os.getcwd(), self.anchor)
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds Azure-only asynchronous analysis jobs backed by the container local filesystem
- returns a job id after extraction and polls short-lived status requests, avoiding the App Service stream timeout
- keeps Vercel on the existing synchronous NDJSON path
- includes the working-directory recovery fix and Azure feature deployment workflow already validated on the Web App

## Validation
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile api/upload.py api/async_jobs.py`
- `npm run build`
- GitHub Action `32626284736` succeeded and deployed the immutable Azure image
- Azure smoke test: upload returned `202`, then the job reached `done`
- Azure real-world 2 GB analysis completed successfully (over 10 minutes) with no HTTP 5xx, OOM, or container restart

## Operational note
Azure jobs and extracted data are intentionally local/ephemeral: an App Service container restart invalidates an in-flight job. No remote storage is introduced.