### PR TITLE
feat: separate upload and analysis progress

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,8 @@
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -855,6 +856,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1137,6 +1145,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1519,6 +1545,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1581,6 +1720,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1677,6 +1826,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1819,6 +1978,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2017,6 +2183,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2025,6 +2201,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2736,6 +2922,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2818,6 +3018,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3049,6 +3256,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3058,6 +3272,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3106,6 +3334,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3121,6 +3366,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3321,6 +3576,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3335,6 +3680,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.11"
   }
 }

--- a/frontend/src/components/upload/UploadProgress.tsx
+++ b/frontend/src/components/upload/UploadProgress.tsx
@@ -1,56 +1,71 @@
 import { useEffect, useRef } from 'react';
-import type { LogLine } from '../../hooks/useUpload';
+import type { AnalysisProgress, LogLine, TransferProgress } from '../../hooks/useUpload';
 
 interface UploadProgressProps {
-  percent: number;
-  stage: string;
+  upload: TransferProgress;
+  analysis: AnalysisProgress;
   log: LogLine[];
 }
 
-export default function UploadProgress({ percent, stage, log }: UploadProgressProps) {
+function formatBytes(value: number) {
+  if (value < 1024) return `${value} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let size = value;
+  let unit = -1;
+  do { size /= 1024; unit += 1; } while (size >= 1024 && unit < units.length - 1);
+  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[unit]}`;
+}
+
+function formatEta(seconds: number | null) {
+  if (seconds === null || !Number.isFinite(seconds)) return 'calculating…';
+  if (seconds < 60) return `${Math.ceil(seconds)}s remaining`;
+  return `${Math.ceil(seconds / 60)}m remaining`;
+}
+
+function ProgressBar({ percent, color }: { percent: number; color: string }) {
+  return (
+    <div className="w-full h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-subtle, rgba(148,163,184,0.2))' }}>
+      <div className="h-full rounded-full transition-all duration-300 ease-out" style={{ width: `${Math.max(2, Math.min(100, percent))}%`, background: color }} />
+    </div>
+  );
+}
+
+export default function UploadProgress({ upload, analysis, log }: UploadProgressProps) {
   const logRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (logRef.current) {
-      logRef.current.scrollTop = logRef.current.scrollHeight;
-    }
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [log.length]);
 
   return (
-    <div className="flex flex-col gap-4 py-8 px-2">
-      <div className="flex items-baseline justify-between">
-        <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{stage || 'Processing archive…'}</p>
-        <span className="text-sm mono" style={{ color: 'var(--accent)' }}>{Math.round(percent)}%</span>
-      </div>
+    <div className="flex flex-col gap-6 py-5 px-2">
+      <section className="flex flex-col gap-2" aria-label="Upload progress">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>Uploading archive</p>
+          <span className="text-sm mono" style={{ color: 'var(--accent)' }}>{Math.round(upload.percent)}%</span>
+        </div>
+        <ProgressBar percent={upload.percent} color="var(--accent)" />
+        <div className="flex flex-wrap justify-between gap-x-3 text-xs mono" style={{ color: 'var(--text-muted)' }}>
+          <span>{formatBytes(upload.loaded)} / {formatBytes(upload.total)}</span>
+          <span>{upload.bytesPerSecond > 0 ? `${formatBytes(upload.bytesPerSecond)}/s` : 'starting…'}</span>
+          <span>{formatEta(upload.etaSeconds)}</span>
+        </div>
+      </section>
 
-      <div
-        className="w-full h-2 rounded-full overflow-hidden"
-        style={{ background: 'var(--bg-subtle, rgba(148,163,184,0.2))' }}
-      >
-        <div
-          className="h-full rounded-full transition-all duration-300 ease-out"
-          style={{ width: `${Math.max(2, Math.min(100, percent))}%`, background: 'var(--accent)' }}
-        />
-      </div>
+      <section className="flex flex-col gap-2" aria-label="Analysis progress">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{analysis.stage || 'Waiting for analysis…'}</p>
+          <span className="text-sm mono" style={{ color: 'var(--accent-purple, var(--accent))' }}>{Math.round(analysis.percent)}%</span>
+        </div>
+        <ProgressBar percent={analysis.percent} color="var(--accent-purple, var(--accent))" />
+      </section>
 
-      <div
-        ref={logRef}
-        className="mono text-xs rounded-lg p-3 h-40 overflow-y-auto leading-6"
-        style={{ background: 'var(--bg-inset, rgba(15,23,42,0.4))', border: '1px solid var(--border)', color: 'var(--text-muted)' }}
-      >
-        {log.length === 0 ? (
-          <span>Starting…</span>
-        ) : (
-          log.map((line, i) => (
-            <div key={i}>
-              <span style={{ color: 'var(--text-secondary)' }}>›</span> {line.message}
-            </div>
-          ))
-        )}
+      <div ref={logRef} className="mono text-xs rounded-lg p-3 h-40 overflow-y-auto leading-6" style={{ background: 'var(--bg-inset, rgba(15,23,42,0.4))', border: '1px solid var(--border)', color: 'var(--text-muted)' }}>
+        {log.length === 0 ? <span>Waiting for analysis output…</span> : log.map((line, i) => <div key={i}><span style={{ color: 'var(--text-secondary)' }}>›</span> {line.message}</div>)}
       </div>
 
       <p className="text-xs text-center" style={{ color: 'var(--text-muted)' }}>
-        Large archives (hundreds of MB) can take a few minutes — this page will update automatically.
+        Upload and analysis run independently. Large archives can take several minutes to analyse.
       </p>
     </div>
   );

--- a/frontend/src/components/upload/uploadMetrics.ts
+++ b/frontend/src/components/upload/uploadMetrics.ts
@@ -1,0 +1,18 @@
+export interface UploadMetrics {
+  percent: number;
+  bytesPerSecond: number;
+  etaSeconds: number | null;
+}
+
+export function uploadMetrics(
+  loaded: number,
+  total: number,
+  startedAt: number,
+  now: number,
+): UploadMetrics {
+  const percent = total > 0 ? Math.min(100, (loaded / total) * 100) : 0;
+  const elapsedSeconds = Math.max(0, (now - startedAt) / 1000);
+  const bytesPerSecond = elapsedSeconds > 0 ? loaded / elapsedSeconds : 0;
+  const etaSeconds = bytesPerSecond > 0 ? Math.max(0, (total - loaded) / bytesPerSecond) : null;
+  return { percent, bytesPerSecond, etaSeconds };
+}

--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -1,43 +1,68 @@
 import { useState } from 'react';
 import type { ReportData } from '../types/report';
+import { uploadMetrics } from '../components/upload/uploadMetrics';
 
 export interface LogLine {
   ts: number;
   message: string;
 }
 
+export interface TransferProgress {
+  percent: number;
+  loaded: number;
+  total: number;
+  bytesPerSecond: number;
+  etaSeconds: number | null;
+}
+
+export interface AnalysisProgress {
+  percent: number;
+  stage: string;
+}
+
 type UploadState =
   | { status: 'idle' }
-  | { status: 'uploading'; percent: number; stage: string; log: LogLine[] }
+  | { status: 'uploading'; upload: TransferProgress; analysis: AnalysisProgress; log: LogLine[] }
   | { status: 'done'; data: ReportData }
   | { status: 'error'; message: string };
 
-// The full response body is a single request that streams newline-delimited
-// JSON (NDJSON) progress lines, ending with a final line containing the full
-// report (or an error). This avoids depending on server-side state surviving
-// across two separate HTTP requests (upload + poll), which isn't guaranteed
-// on serverless platforms like Vercel — see issue #88.
+const initialTransfer: TransferProgress = {
+  percent: 0, loaded: 0, total: 0, bytesPerSecond: 0, etaSeconds: null,
+};
+
 export function useUpload() {
   const [state, setState] = useState<UploadState>({ status: 'idle' });
+
+  function updateAnalysis(percent: number | undefined, stage: string | undefined, log: LogLine[]) {
+    setState((previous) => {
+      if (previous.status !== 'uploading') return previous;
+      const nextLog = stage && log.at(-1)?.message !== stage
+        ? [...log, { ts: Date.now(), message: stage }]
+        : log;
+      return {
+        ...previous,
+        analysis: {
+          percent: percent ?? previous.analysis.percent,
+          stage: stage ?? previous.analysis.stage,
+        },
+        log: nextLog,
+      };
+    });
+  }
 
   async function waitForLocalJob(jobId: string, log: LogLine[]) {
     while (true) {
       await new Promise((resolve) => window.setTimeout(resolve, 1000));
-      const res = await fetch(`/api/job?job_id=${encodeURIComponent(jobId)}`);
-      const job = await res.json();
-      if (!res.ok || job.error) {
-        setState({ status: 'error', message: job.error ?? `HTTP ${res.status}` });
+      const response = await fetch(`/api/job?job_id=${encodeURIComponent(jobId)}`);
+      const job = await response.json();
+      if (!response.ok || job.error) {
+        setState({ status: 'error', message: job.error ?? `HTTP ${response.status}` });
         return;
       }
       if (job.stage && log.at(-1)?.message !== job.stage) {
         log = [...log, { ts: Date.now(), message: job.stage }];
       }
-      setState({
-        status: 'uploading',
-        percent: job.percent ?? 0,
-        stage: job.stage ?? 'Processing archive…',
-        log,
-      });
+      updateAnalysis(job.percent, job.stage, log);
       if (job.status === 'done') {
         setState({ status: 'done', data: job.result });
         return;
@@ -45,77 +70,85 @@ export function useUpload() {
     }
   }
 
-  async function upload(file: File) {
-    setState({ status: 'uploading', percent: 0, stage: 'Uploading archive…', log: [] });
+  function upload(file: File) {
+    let log: LogLine[] = [];
+    let responseOffset = 0;
+    let responseBuffer = '';
+    let finalResult: ReportData | null = null;
+    const startedAt = performance.now();
+
+    setState({
+      status: 'uploading',
+      upload: { ...initialTransfer, total: file.size },
+      analysis: { percent: 0, stage: 'Waiting for upload to finish…' },
+      log,
+    });
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/upload');
+
+    xhr.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return;
+      const metrics = uploadMetrics(event.loaded, event.total, startedAt, performance.now());
+      setState((previous) => previous.status === 'uploading' ? {
+        ...previous,
+        upload: { loaded: event.loaded, total: event.total, ...metrics },
+      } : previous);
+    };
+
+    const consumeLines = (flush = false) => {
+      responseBuffer += xhr.responseText.slice(responseOffset);
+      responseOffset = xhr.responseText.length;
+      const lines = responseBuffer.split('\n');
+      responseBuffer = flush ? '' : (lines.pop() ?? '');
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const data = JSON.parse(line);
+          if (data.error) {
+            setState({ status: 'error', message: data.error });
+            return;
+          }
+          if (data.result) {
+            finalResult = data.result;
+            return;
+          }
+          if (data.log) log = [...log, { ts: Date.now(), message: data.log }];
+          updateAnalysis(data.percent, data.stage, log);
+        } catch {
+          // A chunk can end in the middle of one NDJSON object; keep parsing.
+        }
+      }
+    };
+
+    xhr.onprogress = () => consumeLines();
+    xhr.onerror = () => setState({ status: 'error', message: 'Network error while uploading archive' });
+    xhr.onload = async () => {
+      if (xhr.status === 202) {
+        try {
+          const job = JSON.parse(xhr.responseText);
+          setState((previous) => previous.status === 'uploading' ? {
+            ...previous,
+            upload: { ...previous.upload, percent: 100, loaded: file.size },
+            analysis: { percent: 0, stage: 'Archive uploaded, starting analysis…' },
+          } : previous);
+          await waitForLocalJob(job.job_id, log);
+        } catch {
+          setState({ status: 'error', message: 'Invalid asynchronous job response' });
+        }
+        return;
+      }
+      if (xhr.status < 200 || xhr.status >= 300) {
+        setState({ status: 'error', message: `HTTP ${xhr.status}` });
+        return;
+      }
+      consumeLines(true);
+      if (finalResult) setState({ status: 'done', data: finalResult });
+    };
+
     const form = new FormData();
     form.append('file', file);
-
-    let log: LogLine[] = [];
-
-    try {
-      const res = await fetch('/api/upload', { method: 'POST', body: form });
-      if (!res.ok || !res.body) {
-        let message = `HTTP ${res.status}`;
-        try {
-          const json = await res.json();
-          message = json.error ?? message;
-        } catch {
-          // response wasn't JSON (e.g. platform error page) — keep the HTTP status message
-        }
-        setState({ status: 'error', message });
-        return;
-      }
-
-      if (res.status === 202) {
-        const job = await res.json();
-        await waitForLocalJob(job.job_id, log);
-        return;
-      }
-
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-
-        let newlineIdx: number;
-        while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
-          const line = buffer.slice(0, newlineIdx).trim();
-          buffer = buffer.slice(newlineIdx + 1);
-          if (!line) continue;
-
-          let json: any;
-          try {
-            json = JSON.parse(line);
-          } catch {
-            continue; // ignore malformed/partial line, shouldn't normally happen
-          }
-
-          if (json.error) {
-            setState({ status: 'error', message: json.error });
-            return;
-          }
-          if (json.result) {
-            setState({ status: 'done', data: json.result });
-            return;
-          }
-          if (json.log) {
-            log = [...log, { ts: Date.now(), message: json.log }];
-          }
-          setState((prev) => ({
-            status: 'uploading',
-            percent: json.percent ?? (prev.status === 'uploading' ? prev.percent : 0),
-            stage: json.stage ?? (prev.status === 'uploading' ? prev.stage : ''),
-            log,
-          }));
-        }
-      }
-    } catch (e) {
-      setState({ status: 'error', message: (e as Error).message });
-    }
+    xhr.send(form);
   }
 
   function reset() {

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -88,7 +88,7 @@ export default function Upload() {
               className="upload-panel rounded-2xl p-6 sm:p-10"
               style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
             >
-              <UploadProgress percent={state.percent} stage={state.stage} log={state.log} />
+              <UploadProgress upload={state.upload} analysis={state.analysis} log={state.log} />
             </div>
           ) : (
             <div

--- a/frontend/tests/uploadMetrics.test.ts
+++ b/frontend/tests/uploadMetrics.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { uploadMetrics } from '../src/components/upload/uploadMetrics';
+
+describe('uploadMetrics', () => {
+  it('calculates percent, transfer speed, and ETA from upload progress', () => {
+    expect(uploadMetrics(50_000_000, 200_000_000, 1_000, 11_000)).toEqual({
+      percent: 25,
+      bytesPerSecond: 5_000_000,
+      etaSeconds: 30,
+    });
+  });
+
+  it('does not claim an ETA before time has elapsed', () => {
+    expect(uploadMetrics(0, 200_000_000, 1_000, 1_000)).toEqual({
+      percent: 0,
+      bytesPerSecond: 0,
+      etaSeconds: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- adds a real-time upload progress bar with transferred bytes, upload rate, and ETA
- separates asynchronous analysis progress into its own bar above the existing console
- keeps the same flow compatible with Azure polling and Vercel NDJSON responses

## Validation
- `npm run build`
- `npm exec vitest run tests/uploadMetrics.test.ts`
- `git diff --check`

## Test manually
Use the existing Compose v3 setup with a large archive: verify the upload bar reaches 100% with a speed/ETA, then the separate analysis bar and console continue until the report opens.