### PR TITLE
perf: cache repeated pidstat timestamp conversions

### DIFF
--- a/tests/test_pidstat_top_consumers.py
+++ b/tests/test_pidstat_top_consumers.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'webapp'))
+from domains.procperf.cpu.top_consumers import extract_top_cpu_consumers
+
+
+class PidstatTopConsumersTests(unittest.TestCase):
+    def test_repeated_timestamp_keeps_exact_top_consumer_values(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Path(directory, 'info.txt').write_text('Start Time: Wed Sep 10 14:54:17 UTC 2025\n')
+            source = Path(directory, 'pidstat.txt')
+            source.write_text(
+                '14:54:20 UID PID %usr %system %guest %wait %CPU CPU Command\n'
+                '14:54:20 0 10 3.0 1.0 0.0 2.0 6.0 0 app\n'
+                '14:54:20 0 11 4.0 2.0 0.0 1.0 7.0 0 app\n'
+                '14:54:21 0 12 5.0 0.5 0.0 3.0 8.5 0 worker\n'
+            )
+            result = extract_top_cpu_consumers(str(source), top_n=1)
+
+        self.assertEqual(result['timestamps'], ['2025-09-10 14:54:20', '2025-09-10 14:54:21'])
+        self.assertEqual(result['top_usr']['worker']['values'], [0, 5.0])
+        self.assertEqual(result['top_system']['app']['values'], [2.0, 0])
+        self.assertEqual(result['top_wait']['worker']['values'], [0, 3.0])

--- a/webapp/domains/procperf/cpu/top_consumers.py
+++ b/webapp/domains/procperf/cpu/top_consumers.py
@@ -55,6 +55,7 @@ def extract_top_cpu_consumers(pidstat_input_file, top_n=10):
         'pids': set()    # all PIDs seen for this command
     })
     all_timestamps = set()
+    timestamp_cache = {}
     header_cols = None
 
     # Derive collection date from info.txt so time-only stamps get full datetime
@@ -92,17 +93,17 @@ def extract_top_cpu_consumers(pidstat_input_file, top_n=10):
 
             # Build a full datetime string so Plotly renders a proper time axis
             if collection_date is not None:
-                try:
-                    if offset == 2:
-                        t = datetime.datetime.strptime(
-                            time_str, "%I:%M:%S %p")
-                    else:
-                        t = datetime.datetime.strptime(time_str, "%H:%M:%S")
-                    timestamp = datetime.datetime.combine(
-                        collection_date, t.time()
-                    ).strftime("%Y-%m-%d %H:%M:%S")
-                except ValueError:
-                    timestamp = time_str
+                timestamp = timestamp_cache.get(time_str)
+                if timestamp is None:
+                    try:
+                        if offset == 2:
+                            t = datetime.datetime.strptime(time_str, "%I:%M:%S %p")
+                        else:
+                            t = datetime.datetime.strptime(time_str, "%H:%M:%S")
+                        timestamp = datetime.datetime.combine(collection_date, t.time()).strftime("%Y-%m-%d %H:%M:%S")
+                    except ValueError:
+                        timestamp = time_str
+                    timestamp_cache[time_str] = timestamp
             else:
                 timestamp = time_str
 

--- a/webapp/domains/procperf/io/top_consumers.py
+++ b/webapp/domains/procperf/io/top_consumers.py
@@ -54,6 +54,7 @@ def extract_top_io_consumers(pidstatio_input_file, top_n=10):
         'pids': set()    # all PIDs seen for this command
     })
     all_timestamps = set()
+    timestamp_cache = {}
 
     # Derive collection date from info.txt so time-only stamps get full datetime
     collection_date = parse_collection_date(pidstatio_input_file)
@@ -86,17 +87,14 @@ def extract_top_io_consumers(pidstatio_input_file, top_n=10):
 
             # Build a full datetime string so Plotly renders a proper time axis
             if collection_date is not None:
-                try:
-                    if offset == 2:
-                        t = datetime.datetime.strptime(
-                            time_str, "%I:%M:%S %p")
-                    else:
-                        t = datetime.datetime.strptime(time_str, "%H:%M:%S")
-                    timestamp = datetime.datetime.combine(
-                        collection_date, t.time()
-                    ).strftime("%Y-%m-%d %H:%M:%S")
-                except ValueError:
-                    timestamp = time_str
+                timestamp = timestamp_cache.get(time_str)
+                if timestamp is None:
+                    try:
+                        t = datetime.datetime.strptime(time_str, "%I:%M:%S %p" if offset == 2 else "%H:%M:%S")
+                        timestamp = datetime.datetime.combine(collection_date, t.time()).strftime("%Y-%m-%d %H:%M:%S")
+                    except ValueError:
+                        timestamp = time_str
+                    timestamp_cache[time_str] = timestamp
             else:
                 timestamp = time_str
 

--- a/webapp/domains/procperf/memory/top_consumers.py
+++ b/webapp/domains/procperf/memory/top_consumers.py
@@ -54,6 +54,7 @@ def extract_top_mem_consumers(pidstatmem_input_file, top_n=10):
         'pids': set()    # all PIDs seen for this command
     })
     all_timestamps = set()
+    timestamp_cache = {}
 
     # Derive collection date from info.txt so time-only stamps get full datetime
     collection_date = parse_collection_date(pidstatmem_input_file)
@@ -86,17 +87,14 @@ def extract_top_mem_consumers(pidstatmem_input_file, top_n=10):
 
             # Build a full datetime string so Plotly renders a proper time axis
             if collection_date is not None:
-                try:
-                    if offset == 2:
-                        t = datetime.datetime.strptime(
-                            time_str, "%I:%M:%S %p")
-                    else:
-                        t = datetime.datetime.strptime(time_str, "%H:%M:%S")
-                    timestamp = datetime.datetime.combine(
-                        collection_date, t.time()
-                    ).strftime("%Y-%m-%d %H:%M:%S")
-                except ValueError:
-                    timestamp = time_str
+                timestamp = timestamp_cache.get(time_str)
+                if timestamp is None:
+                    try:
+                        t = datetime.datetime.strptime(time_str, "%I:%M:%S %p" if offset == 2 else "%H:%M:%S")
+                        timestamp = datetime.datetime.combine(collection_date, t.time()).strftime("%Y-%m-%d %H:%M:%S")
+                    except ValueError:
+                        timestamp = time_str
+                    timestamp_cache[time_str] = timestamp
             else:
                 timestamp = time_str
 


### PR DESCRIPTION
## Summary
- caches repeated pidstat timestamp-to-datetime conversions for CPU, I/O, and memory process analysis
- preserves the existing report shape, metrics, timestamps, figures, and lazy process-detail data
- avoids repeated `strptime`/`strftime` calls for every process line at the same timestamp

## Validation
- `python3 -m unittest discover -s tests -v`
- Python compilation and `git diff --check`
- Compose v3 benchmark on the dedicated test host with `big.tar.gz` (121 MB compressed)
  - analysis: **122 s → 61 s** (50% faster)
  - peak RAM: **2.13 GiB → 1.71 GiB**
  - result size: unchanged at 389,524,059 bytes
- Compared baseline and optimized reports: 61 figures, 4,952 Plotly traces, all process-detail sections/timestamp counts, and process-activity content are unchanged
- Small archive: 2 s in both cases and equivalence comparison passed