### PR TITLE
perf: reduce pidstat CPU aggregation overhead

### DIFF
--- a/webapp/domains/procperf/cpu/top_consumers.py
+++ b/webapp/domains/procperf/cpu/top_consumers.py
@@ -120,19 +120,34 @@ def extract_top_cpu_consumers(pidstat_input_file, top_n=10):
 
                 all_timestamps.add(timestamp)
 
-                # Group by Command name (not PID)
-                process_data[command]['pids'].add(pid)
-
-                # For each timestamp, keep the MAX value if multiple PIDs
-                # have the same command (aggregate)
-                current_usr = process_data[command]['usr'].get(timestamp, 0)
-                current_sys = process_data[command]['system'].get(timestamp, 0)
-                current_wait = process_data[command]['wait'].get(timestamp, 0)
-
+                # Group by Command name (not PID).  Keep local references: on
+                # large captures this loop runs millions of times, and repeated
+                # nested defaultdict/dict lookups dominate CPU time.
                 proc = process_data[command]
-                proc['usr'][timestamp] = max(current_usr, usr)
-                proc['system'][timestamp] = max(current_sys, system)
-                proc['wait'][timestamp] = max(current_wait, wait)
+                proc['pids'].add(pid)
+                usr_values = proc['usr']
+                system_values = proc['system']
+                wait_values = proc['wait']
+
+                # For each timestamp, retain the same max-per-command semantics
+                # as before, without allocating/calling max() for every row.
+                previous = usr_values.get(timestamp)
+                if previous is None:
+                    usr_values[timestamp] = usr if usr > 0 else 0
+                elif usr > previous:
+                    usr_values[timestamp] = usr
+
+                previous = system_values.get(timestamp)
+                if previous is None:
+                    system_values[timestamp] = system if system > 0 else 0
+                elif system > previous:
+                    system_values[timestamp] = system
+
+                previous = wait_values.get(timestamp)
+                if previous is None:
+                    wait_values[timestamp] = wait if wait > 0 else 0
+                elif wait > previous:
+                    wait_values[timestamp] = wait
 
             except (ValueError, IndexError):
                 # Skip malformed lines


### PR DESCRIPTION
## Summary
- reduces repeated nested dictionary lookups and max() calls in the CPU pidstat top-consumer aggregator
- preserves max-per-command-per-timestamp semantics and the existing report contract

## Validation
- `python3 -m unittest discover -s tests -v`
- Python compilation and `git diff --check`
- Compose v3 benchmark with the representative large archive:
  - analysis: **61 s → 57 s** after the timestamp-cache optimisation
  - cumulative improvement: **122 s → 57 s** against the original baseline
  - peak RAM: **1.71 GiB → 1.70 GiB**
- Large and small archive report comparisons passed: figures, traces, process-detail sections/timestamps, and process-activity data are unchanged
- Manual validation completed by the user