### PR TITLE
perf: speed report JSON serialization with orjson

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 plotly
+orjson
 setuptools>=78.1.1

--- a/api/upload.py
+++ b/api/upload.py
@@ -39,6 +39,7 @@ WEBAPP_DIR = os.path.join(API_DIR, '..', 'webapp')
 sys.path.insert(0, WEBAPP_DIR)
 
 import plotly.io as pio
+import orjson
 
 from domains.factory import ProcessorFactory
 from domains.procperf.cpu.top_consumers import extract_top_cpu_consumers
@@ -764,7 +765,10 @@ class handler(BaseHTTPRequestHandler):
         pass
 
     def _send_json(self, data, status=200):
-        body = json.dumps(data).encode('utf-8')
+        # The complete large report is several hundred MB.  orjson serializes
+        # it faster than the stdlib and directly supports NumPy values emitted
+        # by Plotly, while preserving the JSON HTTP contract.
+        body = orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY)
         headers = {'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*'}
 
         accepts_gzip = 'gzip' in self.headers.get('Accept-Encoding', '')


### PR DESCRIPTION
## Summary
- uses `orjson` for HTTP JSON responses, including NumPy values emitted by Plotly
- keeps the JSON response schema and report data unchanged
- compact JSON lowers uncompressed report bytes without dropping data

## Validation
- `python3 -m unittest discover -s tests -v`
- Python compilation and `git diff --check`
- Large Compose benchmark: analysis **57 s → 51 s** (~10.5%); cumulative baseline **122 s → 51 s**
- Peak RAM: **1.70 GiB → 1.57 GiB**
- Large and small report structural/content comparisons passed: figures, traces, process-detail timestamps, and process activity are equal
- Manual validation completed by the user