### PR TITLE
fix: show LVM device mapper IDs in layouts and iostat charts

### DIFF
--- a/api/upload.py
+++ b/api/upload.py
@@ -48,7 +48,14 @@ from domains.procperf.memory.top_consumers import extract_top_mem_consumers
 from domains.procinfo.pidstat.pidstatcpu import pidstat_extract_header_line
 from domains.procinfo.pidstat.pidstatio import pidstatio_extract_header_line
 from domains.procinfo.pidstat.pidstatmem import pidstatmem_extract_header_line
-from domains.sysconfig.lvm.lvmviz import parse_pvs, parse_vgs, parse_lvs, parse_dev_mapper
+from domains.sysconfig.lvm.lvmviz import (
+    device_mapper_labels,
+    parse_pvs,
+    parse_vgs,
+    parse_lvs,
+    parse_dev_mapper,
+    relabel_iostat_figures,
+)
 
 import lazy_details
 from workdir import working_directory
@@ -248,8 +255,14 @@ def extract_performance(work_dir: str, progress: 'ProgressReporter | None' = Non
     orig = os.getcwd()
     os.chdir(work_dir)
     perf = {}
+    iostat_device_labels = {}
+    if os.path.exists('lvs.txt') and os.path.exists('ls-l-dev-mapper.txt'):
+        try:
+            iostat_device_labels = device_mapper_labels(parse_lvs(), parse_dev_mapper())
+        except Exception as e:
+            log.warning(f'Could not map device-mapper labels for iostat: {e}')
 
-    def run_processor(ptype: str, fname: str, stage_key: str = '', label: str = '') -> list:
+    def run_processor(ptype: str, fname: str, stage_key: str = '', label: str = '', device_labels: dict | None = None) -> list:
         if not os.path.exists(fname):
             return []
         if progress and stage_key:
@@ -258,6 +271,8 @@ def extract_performance(work_dir: str, progress: 'ProgressReporter | None' = Non
             proc = ProcessorFactory.create_processor(ptype, fname)
             _, figs = proc.process()
             result = [fig_to_dict(f) for f in figs]
+            if device_labels:
+                result = relabel_iostat_figures(result, device_labels)
         except Exception as e:
             log.warning(f'{ptype} processor failed: {e}')
             result = []
@@ -274,8 +289,12 @@ def extract_performance(work_dir: str, progress: 'ProgressReporter | None' = Non
         perf['memory'] = {'figures': mem_figs}
 
     disk = {}
-    pd_figs = run_processor('diskiostat', 'iostat-data.out', 'perf_disk_iostat', 'Processing disk I/O per-device')
-    pm_figs = run_processor('diskmetrics', 'iostat-data.out', 'perf_disk_metrics', 'Processing disk I/O per-metric')
+    pd_figs = run_processor(
+        'diskiostat', 'iostat-data.out', 'perf_disk_iostat',
+        'Processing disk I/O per-device', iostat_device_labels)
+    pm_figs = run_processor(
+        'diskmetrics', 'iostat-data.out', 'perf_disk_metrics',
+        'Processing disk I/O per-metric', iostat_device_labels)
     hr_figs = run_processor('diskhighres', 'diskstats_log.txt', 'perf_disk_highres', 'Processing high-resolution disk stats')
     if pd_figs:
         disk['per_device'] = {'figures': pd_figs}

--- a/api/upload.py
+++ b/api/upload.py
@@ -48,7 +48,7 @@ from domains.procperf.memory.top_consumers import extract_top_mem_consumers
 from domains.procinfo.pidstat.pidstatcpu import pidstat_extract_header_line
 from domains.procinfo.pidstat.pidstatio import pidstatio_extract_header_line
 from domains.procinfo.pidstat.pidstatmem import pidstatmem_extract_header_line
-from domains.sysconfig.lvm.lvmviz import parse_pvs, parse_vgs, parse_lvs
+from domains.sysconfig.lvm.lvmviz import parse_pvs, parse_vgs, parse_lvs, parse_dev_mapper
 
 import lazy_details
 from workdir import working_directory
@@ -200,10 +200,17 @@ def extract_sysconfig(work_dir: str) -> dict:
             vgs = parse_vgs()   # [(vg_name, vg_size, vg_free), ...]
             lvs = parse_lvs()   # [(lv_name, vg_name, lv_size, lv_type, ...), ...]
             os.chdir(orig)
+            dev_mapper = parse_dev_mapper(os.path.join(work_dir, 'ls-l-dev-mapper.txt'))
             lvm_data['topology'] = {
                 'pvs': [{'name': p[0], 'vg': p[1], 'size': p[2], 'free': p[3]} for p in pvs],
                 'vgs': [{'name': v[0], 'size': v[1], 'free': v[2]} for v in vgs],
-                'lvs': [{'name': l[0], 'vg': l[1], 'size': l[2], 'type': l[3]} for l in lvs],
+                'lvs': [
+                    {
+                        'name': l[0], 'vg': l[1], 'size': l[2], 'type': l[3],
+                        'device_mapper': dev_mapper.get(f'{l[1]}-{l[0]}'),
+                    }
+                    for l in lvs
+                ],
             }
         except Exception as e:
             log.warning(f'LVM topology parse failed: {e}')

--- a/frontend/src/components/report/sysconfig/LvmDiagram.tsx
+++ b/frontend/src/components/report/sysconfig/LvmDiagram.tsx
@@ -51,7 +51,7 @@ function VgCard({ name, size, free, pvCount, lvCount }: {
   );
 }
 
-function LvCard({ name, size, type }: { name: string; size: string; type: string }) {
+function LvCard({ name, size, type, device_mapper }: { name: string; size: string; type: string; device_mapper?: string }) {
   return (
     <div className="rounded-lg px-3 py-2 text-xs" style={{
       background: tinted(LV_COLOR, 12),
@@ -60,6 +60,7 @@ function LvCard({ name, size, type }: { name: string; size: string; type: string
       <div className="font-semibold truncate" style={{ color: LV_COLOR }}>{name}</div>
       <div style={{ color: 'var(--text-secondary)' }}>Size: {size}</div>
       <div style={{ color: 'var(--text-muted)' }}>{type}</div>
+      {device_mapper && <div style={{ color: 'var(--text-muted)' }}>Device: {device_mapper}</div>}
     </div>
   );
 }

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -30,7 +30,7 @@ export interface SysConfigData {
     topology?: {
       pvs: { name: string; vg: string; size: string; free: string }[];
       vgs: { name: string; size: string; free: string }[];
-      lvs: { name: string; vg: string; size: string; type: string }[];
+      lvs: { name: string; vg: string; size: string; type: string; device_mapper?: string }[];
     };
     pvs_raw?: string;
     vgs_raw?: string;

--- a/tests/test_iostat_device_labels.py
+++ b/tests/test_iostat_device_labels.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'webapp'))
+from domains.sysconfig.lvm.lvmviz import relabel_iostat_figures
+
+
+class IostatDeviceLabelsTests(unittest.TestCase):
+    def test_relabels_only_mapped_dm_devices_in_titles_and_legends(self):
+        figures = [{
+            'layout': {'title': {'text': 'Disk Metrics - dm-5'}},
+            'data': [{'name': 'dm-5'}, {'name': 'sda'}],
+        }]
+
+        relabel_iostat_figures(figures, {'dm-5': 'rootvg/rootlv (dm-5)'})
+
+        self.assertEqual(
+            figures[0]['layout']['title']['text'],
+            'Disk Metrics - rootvg/rootlv (dm-5)',
+        )
+        self.assertEqual(figures[0]['data'][0]['name'], 'rootvg/rootlv (dm-5)')
+        self.assertEqual(figures[0]['data'][1]['name'], 'sda')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lvm_device_mapper.py
+++ b/tests/test_lvm_device_mapper.py
@@ -4,7 +4,10 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'webapp'))
-from domains.sysconfig.lvm.lvmviz import parse_dev_mapper
+from domains.sysconfig.lvm.lvmviz import (
+    device_mapper_labels,
+    parse_dev_mapper,
+)
 
 
 class DeviceMapperParserTests(unittest.TestCase):
@@ -20,6 +23,23 @@ class DeviceMapperParserTests(unittest.TestCase):
             {
                 'rootvg-rootlv': 'dm-5',
                 'A10_A_datavg-A10_A_datalv': 'dm-7',
+            },
+        )
+
+    def test_labels_dm_devices_with_their_volume_group_and_logical_volume(self):
+        labels = device_mapper_labels(
+            [('rootlv', 'rootvg'), ('data-lv', 'data-vg')],
+            {
+                'rootvg-rootlv': 'dm-5',
+                'data--vg-data--lv': 'dm-7',
+            },
+        )
+
+        self.assertEqual(
+            labels,
+            {
+                'dm-5': 'rootvg/rootlv (dm-5)',
+                'dm-7': 'data-vg/data-lv (dm-7)',
             },
         )
 

--- a/tests/test_lvm_device_mapper.py
+++ b/tests/test_lvm_device_mapper.py
@@ -1,0 +1,28 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'webapp'))
+from domains.sysconfig.lvm.lvmviz import parse_dev_mapper
+
+
+class DeviceMapperParserTests(unittest.TestCase):
+    def test_maps_lvm_name_to_dm_device(self):
+        content = '''lrwxrwxrwx. 1 root root 7 Aug 7 08:47 /dev/mapper/rootvg-rootlv -> ../dm-5\nlrwxrwxrwx. 1 root root 7 Aug 7 08:47 /dev/mapper/A10_A_datavg-A10_A_datalv -> ../dm-7\ncrw-------. 1 root root 10, 236 Aug 7 08:47 /dev/mapper/control\n'''
+        with tempfile.NamedTemporaryFile('w', delete=False) as source:
+            source.write(content)
+            filename = source.name
+        self.addCleanup(lambda: Path(filename).unlink(missing_ok=True))
+
+        self.assertEqual(
+            parse_dev_mapper(filename),
+            {
+                'rootvg-rootlv': 'dm-5',
+                'A10_A_datavg-A10_A_datalv': 'dm-7',
+            },
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webapp/domains/sysconfig/lvm/lvmviz.py
+++ b/webapp/domains/sysconfig/lvm/lvmviz.py
@@ -52,6 +52,21 @@ def parse_lvs(filename='lvs.txt'):
     return lvs
 
 
+def parse_dev_mapper(filename='ls-l-dev-mapper.txt'):
+    """Map an LVM mapper name (``vg-lv``) to its ``dm-N`` device."""
+    dev_mapper_data = {}
+    with open(filename, 'r') as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) < 3 or '->' not in parts:
+                continue
+            mapper_path = parts[-3]
+            dm_number = parts[-1].rsplit('/', 1)[-1]
+            if mapper_path.startswith('/dev/mapper/') and dm_number.startswith('dm-'):
+                dev_mapper_data[mapper_path.rsplit('/', 1)[-1]] = dm_number
+    return dev_mapper_data
+
+
 def create_graph(pvs, vgs, lvs):
     """Legacy function wrapper for backward compatibility."""
     from graphviz import Digraph

--- a/webapp/domains/sysconfig/lvm/lvmviz.py
+++ b/webapp/domains/sysconfig/lvm/lvmviz.py
@@ -67,6 +67,39 @@ def parse_dev_mapper(filename='ls-l-dev-mapper.txt'):
     return dev_mapper_data
 
 
+def device_mapper_labels(lvs, dev_mapper_data):
+    """Return ``dm-N`` → human LVM label mappings for chart legends.
+
+    LVM doubles literal dashes in volume-group and logical-volume names in
+    ``/dev/mapper`` paths, so construct the mapper key instead of trying to
+    split it back into two ambiguous names.
+    """
+    labels = {}
+    for lv in lvs:
+        lv_name, vg_name = lv[0], lv[1]
+        mapper_name = f"{vg_name.replace('-', '--')}-{lv_name.replace('-', '--')}"
+        dm_number = dev_mapper_data.get(mapper_name)
+        if dm_number:
+            labels[dm_number] = f"{vg_name}/{lv_name} ({dm_number})"
+    return labels
+
+
+def relabel_iostat_figures(figures, device_labels):
+    """Replace mapped ``dm-N`` labels in iostat chart titles and legends."""
+    if not device_labels:
+        return figures
+    for figure in figures:
+        layout = figure.get('layout', {})
+        title = layout.get('title', {})
+        if isinstance(title, dict) and isinstance(title.get('text'), str):
+            for device, label in device_labels.items():
+                title['text'] = title['text'].replace(f' - {device}', f' - {label}')
+        for trace in figure.get('data', []):
+            if trace.get('name') in device_labels:
+                trace['name'] = device_labels[trace['name']]
+    return figures
+
+
 def create_graph(pvs, vgs, lvs):
     """Legacy function wrapper for backward compatibility."""
     from graphviz import Digraph


### PR DESCRIPTION
## Summary
- shows `dm-N` device-mapper IDs on LVM logical-volume cards
- resolves iostat `dm-N` labels to `VG/LV (dm-N)` in both per-device titles and per-metric legends
- preserves `sd*` and `nvme*` labels unchanged
- handles LVM hyphen escaping (`--`) in mapper names

## Validation
- added regression tests for mapper parsing, hyphenated VG/LV labels, and iostat title/legend relabelling
- `python3 -m unittest discover -s tests -v`
- Python compilation, React production build, and `git diff --check`
- full large archive upload/analysis on the benchmark host passed in 54 s
- verified output includes e.g. `rootvg/rootlv (dm-5)` in both chart variants