### PR TITLE
feat: navigate process-detail snapshots sequentially

### DIFF
--- a/frontend/src/components/report/process_details/timestampNavigation.ts
+++ b/frontend/src/components/report/process_details/timestampNavigation.ts
@@ -1,0 +1,9 @@
+export function adjacentTimestamp(
+  timestamps: readonly string[],
+  selected: string,
+  direction: -1 | 1,
+): string {
+  const index = timestamps.indexOf(selected);
+  if (index < 0) return timestamps[0] ?? '';
+  return timestamps[Math.max(0, Math.min(timestamps.length - 1, index + direction))] ?? '';
+}

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import type { TimestampChunksMeta, ChunkResponse } from '../../types/report';
+import { adjacentTimestamp } from '../report/process_details/timestampNavigation';
 
 interface Props {
   reportId: string;
@@ -103,18 +104,40 @@ export default function DataTable({ reportId, section, meta }: Props) {
     <div>
       {/* Controls */}
       <div className="flex flex-wrap gap-3 mb-4">
-        <div className="flex flex-col gap-1">
-          <label className="text-xs" style={{ color: 'var(--text-secondary)' }}>Timestamp</label>
-          <select
-            value={selectedTs}
-            onChange={e => setSelectedTs(e.target.value)}
-            className="text-sm px-3 py-1.5 rounded-md w-56 focus:outline-none"
-            style={{ ...controlStyle, outlineColor: 'var(--accent)' }}
+        <div className="flex items-end gap-1">
+          <button
+            type="button"
+            onClick={() => setSelectedTs(adjacentTimestamp(timestamps, selectedTs, -1))}
+            disabled={selectedTs === timestamps[0]}
+            aria-label="Previous timestamp"
+            className="text-sm px-2.5 py-1.5 rounded-md disabled:opacity-40"
+            style={controlStyle}
           >
-            {timestamps.map(ts => (
-              <option key={ts} value={ts}>{ts}</option>
-            ))}
-          </select>
+            ←
+          </button>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs" style={{ color: 'var(--text-secondary)' }}>Timestamp</label>
+            <select
+              value={selectedTs}
+              onChange={e => setSelectedTs(e.target.value)}
+              className="text-sm px-3 py-1.5 rounded-md w-56 focus:outline-none"
+              style={{ ...controlStyle, outlineColor: 'var(--accent)' }}
+            >
+              {timestamps.map(ts => (
+                <option key={ts} value={ts}>{ts}</option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={() => setSelectedTs(adjacentTimestamp(timestamps, selectedTs, 1))}
+            disabled={selectedTs === timestamps[timestamps.length - 1]}
+            aria-label="Next timestamp"
+            className="text-sm px-2.5 py-1.5 rounded-md disabled:opacity-40"
+            style={controlStyle}
+          >
+            →
+          </button>
         </div>
         {cmdIdx >= 0 && (
           <div className="flex flex-col gap-1">

--- a/frontend/tests/timestampNavigation.test.ts
+++ b/frontend/tests/timestampNavigation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { adjacentTimestamp } from '../src/components/report/process_details/timestampNavigation';
+
+describe('adjacentTimestamp', () => {
+  const timestamps = ['10:00:00', '10:01:00', '10:02:00'];
+
+  it('returns the next timestamp without passing the final sample', () => {
+    expect(adjacentTimestamp(timestamps, '10:01:00', 1)).toBe('10:02:00');
+    expect(adjacentTimestamp(timestamps, '10:02:00', 1)).toBe('10:02:00');
+  });
+
+  it('returns the previous timestamp without passing the first sample', () => {
+    expect(adjacentTimestamp(timestamps, '10:01:00', -1)).toBe('10:00:00');
+    expect(adjacentTimestamp(timestamps, '10:00:00', -1)).toBe('10:00:00');
+  });
+});


### PR DESCRIPTION
## Summary
- adds previous/next controls beside the Process Details timestamp selector
- prevents navigating beyond the first and last sample
- adds focused unit coverage for timestamp navigation

## Validation
- `npx --prefix frontend vitest run tests/timestampNavigation.test.ts tests/uploadMetrics.test.ts`
- `npm --prefix frontend run build`
- combined Docker integration build and real `small.tar.gz` analysis on the benchmark host (2 s)