### PR TITLE
feat: add capture health summary to system information

### DIFF
--- a/api/capture_health.py
+++ b/api/capture_health.py
@@ -1,0 +1,41 @@
+import re
+
+
+def _bytes_from_kib(value: str) -> int | None:
+    try:
+        return int(value) * 1024
+    except (TypeError, ValueError):
+        return None
+
+
+def summarize_capture_health(lscpu: str, sar_load: str, meminfo: str) -> dict:
+    """Return a small, source-derived capture health summary; omit absent inputs."""
+    summary: dict = {}
+    cpu_match = re.search(r'^CPU\(s\):\s*(\d+)', lscpu, re.MULTILINE)
+    cpu_count = int(cpu_match.group(1)) if cpu_match else 0
+    if cpu_count:
+        summary['cpu_count'] = cpu_count
+
+    peak_load: float | None = None
+    for line in sar_load.splitlines():
+        values = re.findall(r'\d+(?:\.\d+)?', line)
+        if len(values) >= 5 and not line.lower().startswith(('average', 'runq')):
+            try:
+                load_1m = float(values[-4])
+            except ValueError:
+                continue
+            peak_load = max(peak_load or load_1m, load_1m)
+    if peak_load is not None and cpu_count:
+        summary['peak_normalized_load_1m'] = round(peak_load / cpu_count, 3)
+
+    fields = {}
+    for line in meminfo.splitlines():
+        match = re.match(r'^(MemTotal|MemAvailable|SwapTotal|SwapFree):\s*(\d+)', line)
+        if match:
+            fields[match.group(1)] = _bytes_from_kib(match.group(2))
+    if fields.get('MemAvailable') is not None:
+        summary['min_available_memory_bytes'] = fields['MemAvailable']
+    if fields.get('SwapTotal') is not None and fields.get('SwapFree') is not None:
+        summary['peak_swap_used_bytes'] = max(0, fields['SwapTotal'] - fields['SwapFree'])
+
+    return summary

--- a/api/upload.py
+++ b/api/upload.py
@@ -58,6 +58,7 @@ from domains.sysconfig.lvm.lvmviz import (
 )
 
 import lazy_details
+from capture_health import summarize_capture_health
 from workdir import working_directory
 
 logging.basicConfig(level=logging.WARNING)
@@ -160,6 +161,14 @@ def extract_metadata(work_dir: str) -> dict:
                 break
 
     return meta
+
+
+def extract_capture_health(work_dir: str) -> dict:
+    return summarize_capture_health(
+        read_safe(os.path.join(work_dir, 'lscpu.txt')),
+        read_safe(os.path.join(work_dir, 'sar-load-avg.txt')),
+        read_safe(os.path.join(work_dir, 'meminfo.txt')),
+    )
 
 
 # ── System Configuration ─────────────────────────────────────────────────────
@@ -741,6 +750,9 @@ def _run_local_analysis(job_id: str, report_id: str, work_dir: str, weights: dic
         reporter = ProgressReporter(emit, weights)
         report: dict = {'report_id': report_id}
         report['metadata'] = extract_metadata(work_dir)
+        capture_health = extract_capture_health(work_dir)
+        if capture_health:
+            report['capture_health'] = capture_health
         reporter.flat(1, 'Reading archive metadata')
 
         sc = extract_sysconfig(work_dir)
@@ -946,6 +958,9 @@ class handler(BaseHTTPRequestHandler):
 
             report: dict = {'report_id': hex_id}
             report['metadata'] = extract_metadata(work_dir)
+            capture_health = extract_capture_health(work_dir)
+            if capture_health:
+                report['capture_health'] = capture_health
 
             reporter.flat(1, 'Reading archive metadata')
 

--- a/frontend/src/components/report/CaptureHealthPanel.tsx
+++ b/frontend/src/components/report/CaptureHealthPanel.tsx
@@ -1,0 +1,26 @@
+import type { CaptureHealth } from '../../types/report';
+
+function formatBytes(value?: number) {
+  if (value === undefined) return '—';
+  return `${(value / 1024 ** 3).toFixed(2)} GiB`;
+}
+
+export default function CaptureHealthPanel({ data }: { data: CaptureHealth }) {
+  const cards = [
+    ['Peak load / CPU', data.peak_normalized_load_1m?.toFixed(2) ?? '—', '1-minute load, normalized by logical CPUs'],
+    ['Available memory', formatBytes(data.min_available_memory_bytes), 'Snapshot recorded at collection'],
+    ['Swap in use', formatBytes(data.peak_swap_used_bytes), 'Snapshot recorded at collection'],
+    ['Logical CPUs', data.cpu_count?.toLocaleString() ?? '—', 'Reported by lscpu'],
+  ];
+  return (
+    <section className="grid grid-cols-2 xl:grid-cols-4 gap-4 mb-6" aria-label="Capture health summary">
+      {cards.map(([label, value, description]) => (
+        <div key={label} className="rounded-xl p-4" style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border)' }}>
+          <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{label}</p>
+          <p className="text-2xl font-semibold mt-2" style={{ color: 'var(--text-primary)' }}>{value}</p>
+          <p className="text-xs mt-2" style={{ color: 'var(--text-muted)' }}>{description}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/report/sysconfig/SysConfigTab.tsx
+++ b/frontend/src/components/report/sysconfig/SysConfigTab.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
-import type { SysConfigData } from '../../../types/report';
+import type { CaptureHealth, SysConfigData } from '../../../types/report';
+import CaptureHealthPanel from '../CaptureHealthPanel';
 import SubTabBar from '../../ui/SubTabBar';
 import TextBlock from '../../ui/TextBlock';
 import LvmDiagram from './LvmDiagram';
 
-interface Props { data: SysConfigData; }
+interface Props {
+  data: SysConfigData;
+  captureHealth?: CaptureHealth;
+}
 
 const SUBTABS = [
   { id: 'information', label: 'Information' },
@@ -18,7 +22,7 @@ const SUBTABS = [
   { id: 'security',    label: 'Security' },
 ];
 
-export default function SysConfigTab({ data }: Props) {
+export default function SysConfigTab({ data, captureHealth }: Props) {
   const [sub, setSub] = useState('information');
 
   const available = SUBTABS.map(t => ({
@@ -51,6 +55,7 @@ export default function SysConfigTab({ data }: Props) {
         {activeSub === 'information' && (
           <>
             <TextBlock label="Runtime Information" content={data.information?.runtime_info} />
+            {captureHealth && <CaptureHealthPanel data={captureHealth} />}
             <TextBlock label="OS Release" content={data.information?.os_release} />
           </>
         )}

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -9,7 +9,6 @@ import PerformanceTab from '../components/report/performance/PerformanceTab';
 import ProcessActivityTab from '../components/report/process_activity/ProcessActivityTab';
 import ProcessDetailsTab from '../components/report/process_details/ProcessDetailsTab';
 import AboutTab from '../components/report/AboutTab';
-import CaptureHealthPanel from '../components/report/CaptureHealthPanel';
 
 const MAIN_TABS = [
   { id: 'sysconfig',        label: 'System Configuration' },
@@ -80,9 +79,8 @@ export default function Report() {
 
       {/* Tab content */}
       <main className="flex-1 w-[80%] max-w-[1600px] mx-auto w-full px-6 py-6">
-        {effectiveTab === 'sysconfig' && data.capture_health && <CaptureHealthPanel data={data.capture_health} />}
         {effectiveTab === 'sysconfig' && data.sysconfig && (
-          <SysConfigTab data={data.sysconfig} />
+          <SysConfigTab data={data.sysconfig} captureHealth={data.capture_health} />
         )}
         {effectiveTab === 'performance' && data.performance && (
           <PerformanceTab data={data.performance} />

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -9,6 +9,7 @@ import PerformanceTab from '../components/report/performance/PerformanceTab';
 import ProcessActivityTab from '../components/report/process_activity/ProcessActivityTab';
 import ProcessDetailsTab from '../components/report/process_details/ProcessDetailsTab';
 import AboutTab from '../components/report/AboutTab';
+import CaptureHealthPanel from '../components/report/CaptureHealthPanel';
 
 const MAIN_TABS = [
   { id: 'sysconfig',        label: 'System Configuration' },
@@ -79,6 +80,7 @@ export default function Report() {
 
       {/* Tab content */}
       <main className="flex-1 w-[80%] max-w-[1600px] mx-auto w-full px-6 py-6">
+        {effectiveTab === 'sysconfig' && data.capture_health && <CaptureHealthPanel data={data.capture_health} />}
         {effectiveTab === 'sysconfig' && data.sysconfig && (
           <SysConfigTab data={data.sysconfig} />
         )}

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -71,9 +71,17 @@ export interface ProcessDetailsData {
   iotop?: TimestampChunksMeta;
 }
 
+export interface CaptureHealth {
+  cpu_count?: number;
+  peak_normalized_load_1m?: number;
+  min_available_memory_bytes?: number;
+  peak_swap_used_bytes?: number;
+}
+
 export interface ReportData {
   report_id: string;
   metadata: ReportMetadata;
+  capture_health?: CaptureHealth;
   sysconfig?: SysConfigData;
   performance?: PerformanceData;
   process_activity?: ProcessActivityData;

--- a/tests/test_capture_health.py
+++ b/tests/test_capture_health.py
@@ -1,0 +1,23 @@
+import unittest
+
+from api.capture_health import summarize_capture_health
+
+
+class CaptureHealthTests(unittest.TestCase):
+    def test_summarizes_normalized_load_memory_and_swap_pressure(self):
+        summary = summarize_capture_health(
+            lscpu='CPU(s):                          8\n',
+            sar_load='12:00:01 runq-sz plist-sz ldavg-1 ldavg-5 ldavg-15 blocked\n12:00:02 3 200 4.00 2.00 1.00 1\n',
+            meminfo='MemTotal:       16777216 kB\nMemAvailable:    2097152 kB\nSwapTotal:        1048576 kB\nSwapFree:          524288 kB\n',
+        )
+        self.assertEqual(summary['cpu_count'], 8)
+        self.assertEqual(summary['peak_normalized_load_1m'], 0.5)
+        self.assertEqual(summary['min_available_memory_bytes'], 2147483648)
+        self.assertEqual(summary['peak_swap_used_bytes'], 536870912)
+
+    def test_omits_unavailable_metrics(self):
+        self.assertEqual(summarize_capture_health('', '', ''), {})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- derives CPU-normalized load, available memory, swap in use and logical CPU count from collected sources
- renders the compact summary only in System Configuration → Information, between Runtime Information and OS Release
- gracefully omits absent measurements

## Validation
- `python3 -m unittest discover -s tests -v` (10 passed)
- `npm --prefix frontend run build`
- Docker build and real `small.tar.gz` analysis on benchmark host