### PR TITLE
feat: surface filesystem capacity risks

### DIFF
--- a/api/storage_capacity.py
+++ b/api/storage_capacity.py
@@ -1,0 +1,34 @@
+PSEUDO_FILESYSTEMS = {
+    'devtmpfs', 'tmpfs', 'sysfs', 'proc', 'securityfs', 'devpts', 'cgroup', 'cgroup2',
+    'mqueue', 'debugfs', 'tracefs', 'configfs',
+}
+
+
+def summarize_filesystems(df_h: str) -> list[dict]:
+    """Parse real filesystem capacity rows from `df -h` output."""
+    rows = []
+    for line in df_h.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        filesystem, size, used, available, percentage = parts[:5]
+        mount = ' '.join(parts[5:])
+        if filesystem in PSEUDO_FILESYSTEMS or filesystem.startswith('/dev/loop') or mount.startswith('/snap'):
+            continue
+        if not percentage.endswith('%'):
+            continue
+        try:
+            use_percent = int(percentage[:-1])
+        except ValueError:
+            continue
+        severity = 'critical' if use_percent >= 95 else 'warning' if use_percent >= 85 else 'normal'
+        rows.append({
+            'filesystem': filesystem,
+            'size': size,
+            'used': used,
+            'available': available,
+            'use_percent': use_percent,
+            'mount': mount,
+            'severity': severity,
+        })
+    return rows

--- a/api/upload.py
+++ b/api/upload.py
@@ -59,6 +59,7 @@ from domains.sysconfig.lvm.lvmviz import (
 
 import lazy_details
 from capture_health import summarize_capture_health
+from storage_capacity import summarize_filesystems
 from workdir import working_directory
 
 logging.basicConfig(level=logging.WARNING)
@@ -194,6 +195,9 @@ def extract_sysconfig(work_dir: str) -> dict:
         if v:
             storage[key] = v
     if storage:
+        capacity = summarize_filesystems(storage.get('df', ''))
+        if capacity:
+            storage['capacity'] = capacity
         sc['storage'] = storage
 
     # LVM — parse topology + raw text; no graphviz needed (diagram rendered in React)

--- a/frontend/src/components/report/sysconfig/SysConfigTab.tsx
+++ b/frontend/src/components/report/sysconfig/SysConfigTab.tsx
@@ -10,6 +10,49 @@ interface Props {
   captureHealth?: CaptureHealth;
 }
 
+function CapacityRiskTable({ capacity }: { capacity: NonNullable<SysConfigData['storage']>['capacity'] }) {
+  if (!capacity?.length) return null;
+
+  return (
+    <section className="mb-4 overflow-x-auto rounded-lg border border-[var(--border)]" aria-labelledby="capacity-risk-heading">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--border)] px-4 py-3">
+        <div>
+          <h3 id="capacity-risk-heading" className="font-semibold">Filesystem capacity risk</h3>
+          <p className="text-sm text-[var(--text-muted)]">Warning at 85%; critical at 95% used.</p>
+        </div>
+      </div>
+      <table className="w-full min-w-[42rem] text-left text-sm">
+        <thead className="bg-[var(--bg-elevated)] text-[var(--text-muted)]">
+          <tr>
+            <th scope="col" className="px-4 py-2 font-medium">Mount</th>
+            <th scope="col" className="px-4 py-2 font-medium">Filesystem</th>
+            <th scope="col" className="px-4 py-2 font-medium">Used</th>
+            <th scope="col" className="px-4 py-2 font-medium">Available</th>
+            <th scope="col" className="px-4 py-2 font-medium">Size</th>
+            <th scope="col" className="px-4 py-2 font-medium">Risk</th>
+          </tr>
+        </thead>
+        <tbody>
+          {capacity.map(row => (
+            <tr key={`${row.filesystem}-${row.mount}`} className="border-t border-[var(--border)]">
+              <th scope="row" className="px-4 py-2 font-medium">{row.mount}</th>
+              <td className="mono px-4 py-2">{row.filesystem}</td>
+              <td className="px-4 py-2">{row.used} ({row.use_percent}%)</td>
+              <td className="px-4 py-2">{row.available}</td>
+              <td className="px-4 py-2">{row.size}</td>
+              <td className="px-4 py-2">
+                <span className={row.severity === 'critical' ? 'threshold-critical rounded px-2 py-1 font-medium' : row.severity === 'warning' ? 'threshold-warning rounded px-2 py-1 font-medium' : 'rounded bg-[var(--bg-elevated)] px-2 py-1 font-medium'}>
+                  {row.severity === 'normal' ? 'Normal' : row.severity === 'warning' ? 'Warning' : 'Critical'}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
 const SUBTABS = [
   { id: 'information', label: 'Information' },
   { id: 'hardware',    label: 'Hardware' },
@@ -67,6 +110,7 @@ export default function SysConfigTab({ data, captureHealth }: Props) {
         )}
         {activeSub === 'storage' && (
           <>
+            <CapacityRiskTable capacity={data.storage?.capacity} />
             <TextBlock label="lsscsi" content={data.storage?.lsscsi} />
             <TextBlock label="lsblk -f" content={data.storage?.lsblk} />
             <TextBlock label="df -h" content={data.storage?.df} />

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -25,7 +25,21 @@ export interface ReportMetadata {
 export interface SysConfigData {
   information?: { runtime_info: string; os_release: string };
   hardware?: { lshw: string; dmidecode: string };
-  storage?: { lsscsi?: string; lsblk?: string; df?: string; ls_dev_mapper?: string };
+  storage?: {
+    lsscsi?: string;
+    lsblk?: string;
+    df?: string;
+    ls_dev_mapper?: string;
+    capacity?: {
+      filesystem: string;
+      size: string;
+      used: string;
+      available: string;
+      use_percent: number;
+      mount: string;
+      severity: 'normal' | 'warning' | 'critical';
+    }[];
+  };
   lvm?: {
     topology?: {
       pvs: { name: string; vg: string; size: string; free: string }[];

--- a/tests/test_storage_capacity.py
+++ b/tests/test_storage_capacity.py
@@ -1,0 +1,29 @@
+import unittest
+
+from api.storage_capacity import summarize_filesystems
+
+
+class StorageCapacityTests(unittest.TestCase):
+    def test_keeps_real_mounts_and_marks_capacity_severity(self):
+        rows = summarize_filesystems(
+            'Filesystem Size Used Avail Use% Mounted on\n'
+            '/dev/sda1 100G 92G 8G 92% /\n'
+            'tmpfs 1G 1G 0 100% /run\n'
+            '/dev/loop0 50M 50M 0 100% /snap/core\n'
+        )
+        self.assertEqual(rows, [{
+            'filesystem': '/dev/sda1', 'size': '100G', 'used': '92G', 'available': '8G',
+            'use_percent': 92, 'mount': '/', 'severity': 'warning',
+        }])
+
+    def test_uses_critical_threshold_at_95_percent(self):
+        rows = summarize_filesystems('Filesystem Size Used Avail Use% Mounted on\n/dev/x 10G 10G 0 95% /data\n')
+        self.assertEqual(rows[0]['severity'], 'critical')
+
+    def test_uses_warning_threshold_at_85_percent(self):
+        rows = summarize_filesystems('Filesystem Size Used Avail Use% Mounted on\n/dev/x 10G 8.5G 1.5G 85% /data\n')
+        self.assertEqual(rows[0]['severity'], 'warning')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- converts `df -h` into a structured capacity table in System Configuration → Storage
- filters pseudo-filesystems, loop devices and `/snap` mounts
- labels capacity at 85% warning and 95% critical while preserving raw diagnostics

## Validation
- parser tests cover pseudo-filesystem filtering and severity thresholds
- frontend type/build validation performed by the feature branch workflow