### PR TITLE
ci: deploy Azure from main image

### DIFF
--- a/.github/workflows/docker-react-publish.yml
+++ b/.github/workflows/docker-react-publish.yml
@@ -45,12 +45,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-azure-feature:
-    name: Deploy published feature image to Azure
+  deploy-azure-main:
+    name: Deploy published main image to Azure
     needs: build-and-push
-    # The deployment stays entirely on the feature branch. main continues to
-    # build and publish its existing latest image without any Azure deployment.
-    if: github.ref == 'refs/heads/chore/azure-react-webapp'
+    # Production follows main and deploys the immutable image produced above.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy the immutable image already published by the build job


### PR DESCRIPTION
## Summary
- makes the Azure deployment job run only for pushes to `main`
- deploys the immutable SHA image already built and pushed by the same workflow
- preserves image publication for `main` (`latest` plus SHA)
- keeps feature and release branch pushes free of Azure production deployments

## Validation
- reviewed the workflow diff
- `git diff --check` passed

Production deployment will occur only after this PR is merged through `release/v2.3.4` and that release is then merged into `main`.